### PR TITLE
Backend architecture refactor + Ollama streaming + URL routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+Compact gotchas for this repo. For commands, architecture, and API docs, see `CLAUDE.md` — that file is the canonical reference.
+
+## Setup gotchas
+
+- **Two `.env` files**: root `.env` (Postgres creds) + `backend/.env` (API keys, per `backend/.env.example`). Both needed.
+- **Dual lockfiles** (`package-lock.json` + `yarn.lock`) in both `backend/` and `app/`. Stick with **npm** (CLAUDE.md convention).
+- **Ollama** required for local models. Docker uses `host.docker.internal` to reach it. Script: `scripts/pull-models.sh`.
+
+## Backend surprises
+
+- **Provider auto-discovery**: `registerProviders()` (`providers/index.ts`) scans `providers/` for files exporting `register()`. Drop a file — no manual wiring.
+- **Tool contract**: tools export `RunnableTool<TInput>` (`tools/types.ts`) with `{ definition, schema, run }`. Register in `tools/index.ts`.
+- **Agentic loop**: 10-iteration max, tools execute **in parallel** (`Promise.all`), outputs **truncated at 10K chars** (`toolExecutor.ts:94`).
+- **SSRF protection**: `fetchUrl` tool blocks private IP ranges.
+- **Google Calendar**: needs `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN`.
+- **SSE format** (Anthropic-style): `message_start` → `content_block_delta` (text) / `content_block_start` (tool_use) / `content_block_stop` (tool_result) → `message_stop`. See `sse/types.ts`.
+- **ESLint**: flat config `eslint.config.mjs`. The `.eslintrc.json` is legacy.
+- **Prisma**: schema has 3 models (`Thread`, `Message`, `ToolCall`). After changes: `prisma generate` then `migrate dev`.
+- **Tests** excluded from `tsc` compilation.
+- **Backend test**: `NODE_OPTIONS='--max-old-space-size=4096' npx jest --forceExit --detectOpenHandles`.
+
+## Frontend surprises
+
+- **CRA ESLint disabled** at start (`DISABLE_ESLINT_PLUGIN=true`).
+- **Prettier config** at `app/.prettierrc` only (none in `backend/`).
+- **Shared types** via `@shared/*` path alias → `../shared/` — used by both packages.
+
+## Missing infra
+
+- **No CI workflows** exist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,5 +143,5 @@ Llama and DeepSeek local models require Ollama running on port 11434. Docker use
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/001-convert-js-to-ts/plan.md`
+at `specs/002-backend-refactor/plan.md`
 <!-- SPECKIT END -->

--- a/backend/src/controllers/messageController.ts
+++ b/backend/src/controllers/messageController.ts
@@ -1,156 +1,76 @@
 import { Request, Response } from 'express';
-import { getThreadById } from '../services/threadService';
-import {
-  createMessage,
-  getByThread,
-  updateMessageStatus,
-  countByThread,
-  incrementThreadTokens,
-} from '../services/messageService';
+import { getThreadById, incrementThreadTokens } from '../services/threadService';
+import { createMessage, getByThread, updateMessageStatus, countByThread } from '../services/messageService';
 import { processMessage } from '../services/chatService';
 import { contextService } from '../services/contextService';
+import { SSEWriter } from '../sse/sseWriter';
+import { extractTextContent } from '../providers/utils';
 import { ContentBlockParam } from '../types/content';
-import { ToolCall, ToolResult } from '../types/messages';
+import { BadRequestError, NotFoundError } from '../errors';
 import logger from '../config/logger';
 import prisma from '../config/database';
 
 export async function handleGetMessages(req: Request, res: Response) {
+  const start = Date.now();
+  const log = (req.log || logger).child({ operation: 'getMessages', threadId: req.params.id });
   const thread = await getThreadById(req.params.id as string, req.user!.id);
-  if (!thread) {
-    return res.status(404).json({ error: 'Thread not found' });
-  }
+  if (!thread) throw new NotFoundError('Thread not found');
 
   const beforeId = req.query.before_id as string | undefined;
   const limit = req.query.limit ? Number(req.query.limit) : undefined;
 
   const messages = await getByThread(thread.id, beforeId, limit);
+  log.info({ count: messages.length, durationMs: Date.now() - start }, 'Messages fetched');
   return res.json(messages);
 }
 
 export async function handleSendMessage(req: Request, res: Response) {
   const thread = await getThreadById(req.params.id as string, req.user!.id);
-  if (!thread) {
-    return res.status(404).json({ error: 'Thread not found' });
-  }
+  if (!thread) throw new NotFoundError('Thread not found');
 
   const { content, tools: selectedTools } = req.body as { content?: ContentBlockParam[]; tools?: string[] };
   if (!content || !Array.isArray(content) || content.length === 0) {
-    return res.status(400).json({ error: 'content is required and must be a non-empty array' });
+    throw new BadRequestError('content is required and must be a non-empty array');
   }
 
-  const log = (req.log || logger).child({ threadId: thread.id, model: thread.model });
-
-  // 1. Persist user message
-  const userMessage = await createMessage({
-    threadId: thread.id,
-    role: 'user',
-    content,
-    status: 'complete',
-  });
-
-  // 2. Create assistant placeholder
+  const start = Date.now();
+  const log = (req.log || logger).child({ operation: 'sendMessage', threadId: thread.id, model: thread.model });
+  const userMessage = await createMessage({ threadId: thread.id, role: 'user', content, status: 'complete' });
   const assistantMessage = await createMessage({
-    threadId: thread.id,
-    role: 'assistant',
-    content: [],
-    status: 'streaming',
-    modelSnapshot: thread.model,
+    threadId: thread.id, role: 'assistant', content: [], status: 'streaming', modelSnapshot: thread.model,
   });
 
   log.info({ userMsgId: userMessage.id, assistantMsgId: assistantMessage.id }, 'Message pair created');
 
-  // 3. SSE headers
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
-
-  res.write(
-    `data: ${JSON.stringify({
-      type: 'message_start',
-      message_id: assistantMessage.id,
-      assistant_msg_id: assistantMessage.id,
-      user_msg_id: userMessage.id,
-    })}\n\n`,
-  );
+  const writer = new SSEWriter(res);
+  writer.sendMessageStart({ message_id: assistantMessage.id, assistant_msg_id: assistantMessage.id, user_msg_id: userMessage.id });
 
   try {
-    // 4. Delegate to ChatService
     const result = await processMessage(thread, content, selectedTools, {
-      onDelta: (text: string) => {
-        res.write(`data: ${JSON.stringify({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } })}\n\n`);
-      },
-      onToolUseStart: (call: ToolCall) => {
-        res.write(
-          `data: ${JSON.stringify({
-            type: 'content_block_start',
-            index: 0,
-            content_block: { type: 'tool_use', id: call.id, name: call.name, input: call.arguments },
-          })}\n\n`,
-        );
-      },
-      onToolUseResult: (callId: string, name: string, toolResult: ToolResult) => {
-        res.write(
-          `data: ${JSON.stringify({
-            type: 'content_block_stop',
-            index: 0,
-            tool_result: { tool_call_id: callId, name, output: toolResult.output, is_error: toolResult.is_error },
-          })}\n\n`,
-        );
-      },
+      onDelta: (text) => writer.sendDelta(text),
+      onToolUseStart: (call) => writer.sendToolUseStart({ type: 'tool_use', id: call.id, name: call.name, input: call.arguments }),
+      onToolUseResult: (callId, name, toolResult) => writer.sendToolUseResult({ tool_call_id: callId, name, output: toolResult.output, is_error: toolResult.is_error }),
     });
 
-    log.debug({ responseText: result.text }, 'AI response');
+    await updateMessageStatus(assistantMessage.id, 'complete', { content: [{ type: 'text', text: result.text }], stopReason: 'end_turn' });
 
-    // 5. Persist assistant message
-    await updateMessageStatus(assistantMessage.id, 'complete', {
-      content: [{ type: 'text', text: result.text }],
-      stopReason: 'end_turn',
-    });
-
-    // 6. Update thread token count
-    const userText = content
-      .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-      .map((b) => b.text)
-      .join(' ');
-    const estimatedTokens = contextService.estimateTokens(userText + result.text);
-    await incrementThreadTokens(thread.id, estimatedTokens);
-
-    // 7. Invalidate context cache
+    const userText = extractTextContent(content);
+    await incrementThreadTokens(thread.id, contextService.estimateTokens(userText + result.text));
     contextService.invalidate(thread.id);
 
-    // 8. Auto-generate title on first exchange
     const msgCount = await countByThread(thread.id);
     if (msgCount === 2 && !thread.title) {
       const title = userText.substring(0, 60).replace(/\n/g, ' ').trim() || 'New chat';
-      await prisma.thread.update({
-        where: { id: thread.id },
-        data: { title },
-      });
+      await prisma.thread.update({ where: { id: thread.id }, data: { title } });
     }
 
-    // 9. Send done event
-    res.write(
-      `data: ${JSON.stringify({
-        type: 'message_stop',
-        stop_reason: 'end_turn',
-        tool_calls_count: result.toolCallCount,
-      })}\n\n`,
-    );
-    res.end();
+    log.info({ durationMs: Date.now() - start, toolCallCount: result.toolCallCount }, 'Message completed');
+    writer.sendMessageStop('end_turn', result.toolCallCount);
+    writer.end();
   } catch (error: any) {
     log.error({ err: error }, 'Message handling failed');
     await updateMessageStatus(assistantMessage.id, 'error').catch(() => {});
-
-    res.write(
-      `data: ${JSON.stringify({
-        type: 'error',
-        error: {
-          type: 'internal_error',
-          message: error.message || 'Something went wrong',
-          retryable: true,
-        },
-      })}\n\n`,
-    );
-    res.end();
+    writer.sendError({ type: 'internal_error', message: error.message || 'Something went wrong', retryable: true });
+    writer.end();
   }
 }

--- a/backend/src/controllers/threadController.ts
+++ b/backend/src/controllers/threadController.ts
@@ -1,70 +1,57 @@
 import { Request, Response } from 'express';
-import {
-  createThread,
-  listThreads,
-  getThreadById,
-  updateThread,
-  softDeleteThread,
-} from '../services/threadService';
+import { createThread, listThreads, getThreadById, updateThread, softDeleteThread } from '../services/threadService';
 import { getByThread } from '../services/messageService';
+import { BadRequestError, NotFoundError } from '../errors';
+import logger from '../config/logger';
 
 export async function handleCreateThread(req: Request, res: Response) {
+  const start = Date.now();
+  const log = (req.log || logger).child({ operation: 'createThread' });
   const { model, title, system_prompt } = req.body;
-  if (!model) {
-    return res.status(400).json({ error: 'model is required' });
-  }
+  if (!model) throw new BadRequestError('model is required');
 
-  const thread = await createThread(req.user!.id, {
-    model,
-    title,
-    systemPrompt: system_prompt,
-  });
+  const thread = await createThread(req.user!.id, { model, title, systemPrompt: system_prompt });
+  log.info({ threadId: thread.id, model, durationMs: Date.now() - start }, 'Thread created');
   return res.status(201).json(thread);
 }
 
 export async function handleListThreads(req: Request, res: Response) {
+  const start = Date.now();
+  const log = (req.log || logger).child({ operation: 'listThreads' });
   const cursor = req.query.cursor as string | undefined;
   const limit = req.query.limit ? Number(req.query.limit) : undefined;
 
   const threads = await listThreads(req.user!.id, cursor, limit);
+  log.info({ count: threads.length, durationMs: Date.now() - start }, 'Threads listed');
   return res.json(threads);
 }
 
 export async function handleGetThread(req: Request, res: Response) {
+  const start = Date.now();
+  const log = (req.log || logger).child({ operation: 'getThread', threadId: req.params.id });
   const thread = await getThreadById(req.params.id as string, req.user!.id);
-  if (!thread) {
-    return res.status(404).json({ error: 'Thread not found' });
-  }
+  if (!thread) throw new NotFoundError('Thread not found');
 
   const messages = await getByThread(thread.id);
+  log.info({ messageCount: messages.length, durationMs: Date.now() - start }, 'Thread fetched');
   return res.json({ thread, messages });
 }
 
 export async function handleUpdateThread(req: Request, res: Response) {
-  try {
-    const { title, status, system_prompt } = req.body;
-    const thread = await updateThread(req.params.id as string, req.user!.id, {
-      title,
-      status,
-      systemPrompt: system_prompt,
-    });
-    return res.json(thread);
-  } catch (err: any) {
-    if (err.message === 'Thread not found') {
-      return res.status(404).json({ error: err.message });
-    }
-    throw err;
-  }
+  const start = Date.now();
+  const log = (req.log || logger).child({ operation: 'updateThread', threadId: req.params.id });
+  const { title, status, system_prompt } = req.body;
+  const thread = await updateThread(req.params.id as string, req.user!.id, {
+    title, status, systemPrompt: system_prompt,
+  });
+  log.info({ durationMs: Date.now() - start }, 'Thread updated');
+  return res.json(thread);
 }
 
 export async function handleDeleteThread(req: Request, res: Response) {
-  try {
-    const thread = await softDeleteThread(req.params.id as string, req.user!.id);
-    return res.json(thread);
-  } catch (err: any) {
-    if (err.message === 'Thread not found') {
-      return res.status(404).json({ error: err.message });
-    }
-    throw err;
-  }
+  const start = Date.now();
+  const log = (req.log || logger).child({ operation: 'deleteThread', threadId: req.params.id });
+  const thread = await softDeleteThread(req.params.id as string, req.user!.id);
+  log.info({ durationMs: Date.now() - start }, 'Thread deleted');
+  return res.json(thread);
 }

--- a/backend/src/middleware/asyncHandler.ts
+++ b/backend/src/middleware/asyncHandler.ts
@@ -1,0 +1,9 @@
+import { Request, Response, NextFunction } from 'express';
+
+type AsyncRequestHandler = (req: Request, res: Response, next: NextFunction) => Promise<any>;
+
+export function asyncHandler(fn: AsyncRequestHandler) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    fn(req, res, next).catch(next);
+  };
+}

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -2,13 +2,17 @@ import { Request, Response, NextFunction } from 'express';
 import { AppError } from '../errors';
 import logger from '../config/logger';
 
-export function errorHandler(err: Error, _req: Request, res: Response, _next: NextFunction): void {
+export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction): void {
+  const requestId = req.id || (req as any).id;
+  const log = req.log || logger;
+
   if (err instanceof AppError) {
+    log.error({ err, statusCode: err.status, requestId }, err.message);
     res.status(err.status).json(err.toJSON());
     return;
   }
 
-  logger.error({ err }, 'Unhandled error');
+  log.error({ err, statusCode: 500, requestId }, 'Unhandled error');
   res.status(500).json({
     error: {
       type: 'internal_error',

--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -5,16 +5,15 @@ import logger from '../config/logger';
 export const requestLogger = pinoHttp({
   logger,
 
-  // Generate a short request ID for tracing
   genReqId: (req) => {
     const existing = req.headers['x-request-id'];
     if (existing) return existing as string;
     return crypto.randomUUID().slice(0, 8);
   },
 
-  // Attach userId to every log line from this request
   customProps: (req) => ({
     userId: (req as any).user?.id,
+    requestId: req.id,
   }),
 
   // Don't log health check / root endpoint noise

--- a/backend/src/prompts/default.ts
+++ b/backend/src/prompts/default.ts
@@ -1,0 +1,37 @@
+export function getDefaultPrompt(options: { date: string; timezone: string }): string {
+  return `You are a helpful AI assistant with tools. Current date: ${options.date}. User timezone: ${options.timezone}.
+
+CRITICAL RULES - FOLLOW EXACTLY:
+
+1. NEVER use your training data for current information (news, events, weather, calendar, stock prices, sports scores)
+
+2. For ANY current/real-time query, you MUST use the appropriate tool:
+   - Current date/time → get_current_date
+   - News/current events → web_search
+   - Calendar/schedule → google_calendar
+   - Websites/URLs → fetch_url
+   - Math calculations → calculator
+
+3. When a tool returns results, you MUST synthesize them into a helpful answer:
+   - web_search → Read ALL results, filter relevant ones, write a natural summary (NOT a numbered list)
+   - Focus on the most important/recent information
+   - Ignore irrelevant results (off-topic, different languages, spam)
+   - Write in complete sentences, provide context
+   - NEVER say "I don't have access" after receiving tool results
+
+4. ONLY say "I don't have access to [X]" if:
+   - You tried a tool and it FAILED with an error
+   - No tool exists for the request
+
+5. Answer directly from tool results - no filler, no explaining your process
+
+CRITICAL: If you just called a tool and received results, those results are REAL and CURRENT. Use them in your answer. DO NOT claim you don't have access after successfully calling a tool. The tool output is your source of truth.
+
+Example:
+- User: "What's on my calendar?"
+- You call google_calendar → Returns: "Meeting at 2pm"
+- CORRECT response: "You have a meeting at 2pm"
+- WRONG response: "I don't have access to your calendar" (YOU JUST ACCESSED IT!)
+
+REMEMBER: If you call a tool and it succeeds, you MUST use its results in your response. Don't ignore successful tool outputs.`;
+}

--- a/backend/src/prompts/index.ts
+++ b/backend/src/prompts/index.ts
@@ -1,0 +1,18 @@
+import { getDefaultPrompt } from './default';
+import { getSimplePrompt } from './simple';
+
+export interface SystemPromptOptions {
+  supportsTools: boolean;
+  date?: string;
+  timezone?: string;
+}
+
+export function getSystemPrompt(options: SystemPromptOptions): string {
+  const date = options.date ?? new Date().toISOString().split('T')[0];
+  const timezone = options.timezone ?? 'Asia/Dhaka (UTC+6)';
+
+  if (options.supportsTools) {
+    return getDefaultPrompt({ date, timezone });
+  }
+  return getSimplePrompt({ date, timezone });
+}

--- a/backend/src/prompts/simple.ts
+++ b/backend/src/prompts/simple.ts
@@ -1,0 +1,5 @@
+export function getSimplePrompt(options: { date: string; timezone: string }): string {
+  return `You are a helpful AI assistant. Current date: ${options.date}. User timezone: ${options.timezone}.
+
+Answer questions directly and concisely based on your knowledge. If you don't know current information (today's news, live events, real-time data), say "I don't have access to current [X]" - don't make up answers.`;
+}

--- a/backend/src/providers/google.ts
+++ b/backend/src/providers/google.ts
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { AIProvider, ProviderCapabilities } from './types';
+import { AIProvider, ProviderCapabilities, ProviderRegistration } from './types';
 import { ChatCompletionOptions, ChatCompletionResult, ToolCall, ContentBlock } from '../types';
+import { extractTextContent, mapToolResult, buildToolCallContentBlock } from './utils';
 import logger from '../config/logger';
 
 const log = logger.child({ provider: 'google' });
@@ -24,7 +25,6 @@ export class GoogleProvider implements AIProvider {
     const { messages, tools } = options;
     const modelName = options.model || this.model;
 
-    // Convert tool definitions to Gemini format
     const geminiTools = tools && tools.length > 0
       ? [{
           functionDeclarations: tools.map((t) => ({
@@ -40,30 +40,20 @@ export class GoogleProvider implements AIProvider {
       ...(geminiTools && { tools: geminiTools as any }),
     });
 
-    // Convert messages to Gemini format
-    // Gemini uses 'user' and 'model' roles, system prompt is separate
     const systemInstruction = messages
       .filter((m) => m.role === 'system')
-      .map((m) => (typeof m.content === 'string' ? m.content : ''))
+      .map((m) => extractTextContent(m.content))
       .join('\n');
 
     const geminiHistory = messages
       .filter((m) => m.role !== 'system')
       .map((msg) => {
         const role = msg.role === 'assistant' ? 'model' : 'user';
-        let text: string;
+        const text = extractTextContent(msg.content);
 
-        if (typeof msg.content === 'string') {
-          text = msg.content;
-        } else {
-          text = msg.content
-            .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-            .map((b) => b.text)
-            .join(' ');
-
-          // Handle tool results
-          const toolResult = msg.content.find((b) => b.type === 'tool_result');
-          if (toolResult && 'content' in toolResult) {
+        if (Array.isArray(msg.content)) {
+          const toolResult = mapToolResult(msg.content);
+          if (toolResult) {
             return {
               role: 'function' as const,
               parts: [{
@@ -96,7 +86,6 @@ export class GoogleProvider implements AIProvider {
       const contentBlocks: ContentBlock[] = [];
       const toolCalls: ToolCall[] = [];
 
-      // Check for function calls
       const functionCalls = response.functionCalls();
       if (functionCalls && functionCalls.length > 0) {
         for (let i = 0; i < functionCalls.length; i++) {
@@ -107,12 +96,7 @@ export class GoogleProvider implements AIProvider {
             arguments: (fc.args || {}) as Record<string, unknown>,
           };
           toolCalls.push(toolCall);
-          contentBlocks.push({
-            type: 'tool_use',
-            id: toolCall.id,
-            name: toolCall.name,
-            input: toolCall.arguments,
-          });
+          contentBlocks.push(buildToolCallContentBlock(toolCall));
         }
       }
 
@@ -121,12 +105,7 @@ export class GoogleProvider implements AIProvider {
         contentBlocks.unshift({ type: 'text', text });
       }
 
-      return {
-        text,
-        contentBlocks,
-        toolCalls,
-        stopReason: toolCalls.length > 0 ? 'tool_use' : 'end_turn',
-      };
+      return { text, contentBlocks, toolCalls, stopReason: toolCalls.length > 0 ? 'tool_use' : 'end_turn' };
     } catch (error: any) {
       log.error({ err: error, model: modelName }, 'chatCompletion failed');
       throw new Error(`Google AI chat completion failed: ${error.message}`);
@@ -146,4 +125,25 @@ export class GoogleProvider implements AIProvider {
       throw new Error(`Google AI image analysis failed: ${error.message}`);
     }
   }
+}
+
+const CAPABILITIES: ProviderCapabilities = {
+  chatCompletion: true,
+  streaming: false,
+  imageAnalysis: true,
+};
+
+export function register(): ProviderRegistration {
+  return {
+    name: 'google',
+    models: [
+      { key: 'google', provider: 'google', model: 'gemini-2.0-flash', displayName: 'Gemini 2.0 Flash', capabilities: CAPABILITIES },
+    ],
+    capabilities: CAPABILITIES,
+    factory: (modelId: string) => {
+      const apiKey = process.env.GOOGLE_API_KEY;
+      if (!apiKey) throw new Error('GOOGLE_API_KEY not configured');
+      return new GoogleProvider(apiKey, modelId);
+    },
+  };
 }

--- a/backend/src/providers/index.ts
+++ b/backend/src/providers/index.ts
@@ -1,46 +1,49 @@
-import { AIProvider, ModelConfig } from './types';
-import { OllamaProvider } from './ollama';
-import { OpenAIProvider } from './openai';
-import { GoogleProvider } from './google';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AIProvider, ModelConfig, ProviderRegistration } from './types';
+import logger from '../config/logger';
 
 export { AIProvider, ModelConfig } from './types';
 
-// ─── Model → Provider mapping ───
+const log = logger.child({ component: 'providerRegistry' });
 
-const MODEL_REGISTRY: Record<string, ModelConfig> = {
-  lama: {
-    provider: 'ollama',
-    model: 'llama3.2',
-    displayName: 'Llama 3.2',
-    capabilities: { chatCompletion: true, streaming: true, imageAnalysis: false },
-  },
-  deepseek: {
-    provider: 'ollama',
-    model: 'deepseek-r1:8b',
-    displayName: 'DeepSeek R1 8B',
-    capabilities: { chatCompletion: true, streaming: true, imageAnalysis: false },
-  },
-  gemma: {
-    provider: 'ollama',
-    model: 'gemma3:4b',
-    displayName: 'Gemma 3 4B',
-    capabilities: { chatCompletion: true, streaming: true, imageAnalysis: false },
-  },
-  openai: {
-    provider: 'openai',
-    model: 'gpt-4o-mini',
-    displayName: 'GPT-4o Mini',
-    capabilities: { chatCompletion: true, streaming: true, imageAnalysis: true },
-  },
-  google: {
-    provider: 'google',
-    model: 'gemini-2.0-flash',
-    displayName: 'Gemini 2.0 Flash',
-    capabilities: { chatCompletion: true, streaming: false, imageAnalysis: true },
-  },
-};
+const MODEL_REGISTRY: Record<string, ModelConfig> = {};
+const FACTORY_MAP: Record<string, (modelId: string) => AIProvider> = {};
 
-// ─── Factory ───
+const EXCLUDED_FILES = new Set(['index.ts', 'index.js', 'types.ts', 'types.js', 'utils.ts', 'utils.js']);
+
+export function registerProviders(): void {
+  const providersDir = __dirname;
+  const files = fs.readdirSync(providersDir).filter((f) => {
+    if (EXCLUDED_FILES.has(f)) return false;
+    return f.endsWith('.ts') || f.endsWith('.js');
+  });
+
+  for (const file of files) {
+    const modulePath = path.join(providersDir, file);
+    const mod = require(modulePath);
+
+    if (typeof mod.register !== 'function') {
+      log.warn({ file }, 'Provider file has no register() export, skipping');
+      continue;
+    }
+
+    const registration: ProviderRegistration = mod.register();
+
+    if (FACTORY_MAP[registration.name]) {
+      throw new Error(`Duplicate provider name: "${registration.name}"`);
+    }
+
+    FACTORY_MAP[registration.name] = registration.factory;
+
+    for (const model of registration.models) {
+      const key = model.key || model.model;
+      MODEL_REGISTRY[key] = model;
+    }
+
+    log.info({ provider: registration.name, models: registration.models.map(m => m.displayName) }, 'Provider registered');
+  }
+}
 
 export function createProvider(modelType: string): AIProvider {
   const config = MODEL_REGISTRY[modelType];
@@ -48,22 +51,12 @@ export function createProvider(modelType: string): AIProvider {
     throw new Error(`Unknown model type: "${modelType}". Available: ${Object.keys(MODEL_REGISTRY).join(', ')}`);
   }
 
-  switch (config.provider) {
-    case 'ollama':
-      return new OllamaProvider(config.model);
-    case 'openai': {
-      const apiKey = process.env.OPENAI_API_KEY;
-      if (!apiKey) throw new Error('OPENAI_API_KEY not configured');
-      return new OpenAIProvider(apiKey, config.model);
-    }
-    case 'google': {
-      const apiKey = process.env.GOOGLE_API_KEY;
-      if (!apiKey) throw new Error('GOOGLE_API_KEY not configured');
-      return new GoogleProvider(apiKey, config.model);
-    }
-    default:
-      throw new Error(`Unknown provider: "${config.provider}"`);
+  const factory = FACTORY_MAP[config.provider];
+  if (!factory) {
+    throw new Error(`No factory registered for provider: "${config.provider}"`);
   }
+
+  return factory(config.model);
 }
 
 export function getModelConfig(modelType: string): ModelConfig | undefined {

--- a/backend/src/providers/ollama.ts
+++ b/backend/src/providers/ollama.ts
@@ -1,20 +1,16 @@
 import axios from 'axios';
 import { Transform } from 'stream';
-import { AIProvider, ProviderCapabilities } from './types';
+import { AIProvider, ProviderCapabilities, ProviderRegistration } from './types';
 import { ChatCompletionOptions, ChatCompletionResult, ToolCall, ContentBlock } from '../types';
+import { extractTextContent, mapToolResult, buildToolCallContentBlock } from './utils';
 import logger from '../config/logger';
 
 const log = logger.child({ provider: 'ollama' });
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_URL || 'http://host.docker.internal:11434/api';
 
-// Models that support tool calling in Ollama
 const TOOL_CAPABLE_MODELS = ['llama3.2', 'llama3.1', 'mistral', 'mixtral', 'qwen2.5'];
 
-/**
- * Unified Ollama provider — handles llama, deepseek, mistral, and any
- * model available via the Ollama API.
- */
 export class OllamaProvider implements AIProvider {
   readonly name: string;
   readonly capabilities: ProviderCapabilities = {
@@ -43,35 +39,22 @@ export class OllamaProvider implements AIProvider {
         }))
       : undefined;
 
-    log.debug({
-      model,
-      supportsTools,
-      toolsProvided: tools?.length || 0,
-      ollamaToolsCount: ollamaTools?.length || 0,
-    }, 'Tool support check');
+    log.debug({ model, supportsTools, toolsProvided: tools?.length || 0, ollamaToolsCount: ollamaTools?.length || 0 }, 'Tool support check');
 
     const ollamaMessages = messages.map((msg) => {
       const formatted: { role: string; content: string; tool_calls?: { function: { name: string; arguments: Record<string, unknown> } }[] } = {
         role: msg.role,
-        content: '',
+        content: extractTextContent(msg.content),
       };
 
-      if (typeof msg.content === 'string') {
-        formatted.content = msg.content;
-      } else if (Array.isArray(msg.content)) {
-        const textParts = msg.content
-          .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-          .map((b) => b.text);
-        formatted.content = textParts.join(' ');
-
-        const toolResult = msg.content.find((b) => b.type === 'tool_result');
-        if (toolResult && 'content' in toolResult) {
+      if (Array.isArray(msg.content)) {
+        const toolResult = mapToolResult(msg.content);
+        if (toolResult) {
           formatted.role = 'tool';
-          formatted.content = (toolResult as { content?: string }).content || '';
+          formatted.content = toolResult.content;
         }
       }
 
-      // Preserve tool_calls on assistant messages so Ollama can track the tool-call/result turn
       if (msg.tool_calls && msg.tool_calls.length > 0) {
         formatted.tool_calls = msg.tool_calls.map((tc) => ({
           function: { name: tc.name, arguments: tc.arguments },
@@ -82,15 +65,8 @@ export class OllamaProvider implements AIProvider {
     });
 
     try {
-      const request: Record<string, unknown> = {
-        model,
-        messages: ollamaMessages,
-        stream: true,
-      };
-
-      if (ollamaTools) {
-        request.tools = ollamaTools;
-      }
+      const request: Record<string, unknown> = { model, messages: ollamaMessages, stream: true };
+      if (ollamaTools) request.tools = ollamaTools;
 
       log.debug({ model, messageRoles: ollamaMessages.map(m => m.role), messages: ollamaMessages }, 'Sending to Ollama');
 
@@ -106,10 +82,7 @@ export class OllamaProvider implements AIProvider {
         const streamToolCalls: { function: { name: string; arguments: Record<string, unknown> } }[] = [];
 
         const settle = (fn: () => void) => {
-          if (!settled) {
-            settled = true;
-            fn();
-          }
+          if (!settled) { settled = true; fn(); }
         };
 
         response.data.on('data', (chunk: Buffer) => {
@@ -125,9 +98,7 @@ export class OllamaProvider implements AIProvider {
 
               if (textChunk && !settled) {
                 accumulatedText += textChunk;
-                if (!ollamaTools) {
-                  onDelta?.(textChunk);
-                }
+                if (!ollamaTools) onDelta?.(textChunk);
               }
 
               if (parsed.message?.tool_calls && !settled) {
@@ -135,43 +106,28 @@ export class OllamaProvider implements AIProvider {
               }
 
               if (parsed.done) {
-                log.debug({
-                  model,
-                  doneContent: parsed.message?.content,
-                  doneToolCalls: parsed.message?.tool_calls,
-                  doneReason: parsed.done_reason,
-                  accumulatedTextLength: accumulatedText.length,
-                }, 'Ollama done chunk');
+                log.debug({ model, doneReason: parsed.done_reason, accumulatedTextLength: accumulatedText.length }, 'Ollama done chunk');
 
                 settle(() => {
                   const contentBlocks: ContentBlock[] = [];
                   const toolCalls: ToolCall[] = [];
+                  let rawToolCalls = [...streamToolCalls];
 
-                  // Structured tool_calls accumulated from all chunks (including this done chunk)
-                  let rawToolCalls: { function: { name: string; arguments: Record<string, unknown> } }[] =
-                    [...streamToolCalls];
-
-                  // Fallback: some Ollama versions/models emit tool calls as JSON text content
-                  // instead of structured tool_calls. Detect and convert.
                   if (accumulatedText && rawToolCalls.length === 0) {
                     try {
                       const maybeCall = JSON.parse(accumulatedText.trim());
                       const args = maybeCall.parameters ?? maybeCall.arguments;
                       if (typeof maybeCall.name === 'string' && args !== undefined) {
                         rawToolCalls = [{ function: { name: maybeCall.name, arguments: args } }];
-                        accumulatedText = ''; // was a tool call, not user-visible text
+                        accumulatedText = '';
                         log.debug({ toolName: maybeCall.name }, 'Detected text-embedded tool call');
                       }
-                    } catch {
-                      // not JSON — treat as normal text
-                    }
+                    } catch { /* not JSON — treat as normal text */ }
                   }
 
                   if (accumulatedText) {
                     contentBlocks.push({ type: 'text', text: accumulatedText });
-                    if (ollamaTools) {
-                      onDelta?.(accumulatedText);
-                    }
+                    if (ollamaTools) onDelta?.(accumulatedText);
                   }
 
                   for (let i = 0; i < rawToolCalls.length; i++) {
@@ -182,20 +138,10 @@ export class OllamaProvider implements AIProvider {
                       arguments: tc.function.arguments,
                     };
                     toolCalls.push(toolCall);
-                    contentBlocks.push({
-                      type: 'tool_use',
-                      id: toolCall.id,
-                      name: toolCall.name,
-                      input: toolCall.arguments,
-                    });
+                    contentBlocks.push(buildToolCallContentBlock(toolCall));
                   }
 
-                  resolve({
-                    text: accumulatedText,
-                    contentBlocks,
-                    toolCalls,
-                    stopReason: toolCalls.length > 0 ? 'tool_use' : 'end_turn',
-                  });
+                  resolve({ text: accumulatedText, contentBlocks, toolCalls, stopReason: toolCalls.length > 0 ? 'tool_use' : 'end_turn' });
                 });
               }
             } catch (err) {
@@ -247,4 +193,23 @@ export class OllamaProvider implements AIProvider {
       throw new Error(`Ollama text completion failed: ${error.message}`);
     }
   }
+}
+
+const CAPABILITIES: ProviderCapabilities = {
+  chatCompletion: true,
+  streaming: true,
+  imageAnalysis: false,
+};
+
+export function register(): ProviderRegistration {
+  return {
+    name: 'ollama',
+    models: [
+      { key: 'lama', provider: 'ollama', model: 'llama3.2', displayName: 'Llama 3.2', capabilities: CAPABILITIES },
+      { key: 'deepseek', provider: 'ollama', model: 'deepseek-r1:8b', displayName: 'DeepSeek R1 8B', capabilities: CAPABILITIES },
+      { key: 'gemma', provider: 'ollama', model: 'gemma3:4b', displayName: 'Gemma 3 4B', capabilities: CAPABILITIES },
+    ],
+    capabilities: CAPABILITIES,
+    factory: (modelId: string) => new OllamaProvider(modelId),
+  };
 }

--- a/backend/src/providers/openai.ts
+++ b/backend/src/providers/openai.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
-import { AIProvider, ProviderCapabilities } from './types';
+import { AIProvider, ProviderCapabilities, ProviderRegistration } from './types';
 import { ChatCompletionOptions, ChatCompletionResult, ToolCall, ContentBlock } from '../types';
+import { extractTextContent, mapToolResult, buildToolCallContentBlock } from './utils';
 import logger from '../config/logger';
 
 const log = logger.child({ provider: 'openai' });
@@ -24,7 +25,6 @@ export class OpenAIProvider implements AIProvider {
     const { messages, tools } = options;
     const model = options.model || this.model;
 
-    // Convert tool definitions to OpenAI format
     const openaiTools = tools && tools.length > 0
       ? tools.map((t) => ({
           type: 'function' as const,
@@ -36,33 +36,24 @@ export class OpenAIProvider implements AIProvider {
         }))
       : undefined;
 
-    // Convert messages to OpenAI format
     const openaiMessages = messages.map((msg) => {
-      let content: string;
-      if (typeof msg.content === 'string') {
-        content = msg.content;
-      } else if (Array.isArray(msg.content)) {
-        const textParts = msg.content
-          .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-          .map((b) => b.text);
-        content = textParts.join(' ');
+      const content = extractTextContent(msg.content);
 
-        // Handle tool_result → role: tool
-        const toolResult = msg.content.find((b) => b.type === 'tool_result');
-        if (toolResult && 'tool_use_id' in toolResult) {
+      if (Array.isArray(msg.content)) {
+        const toolResult = mapToolResult(msg.content);
+        if (toolResult) {
           return {
             role: 'tool' as const,
-            content: 'content' in toolResult ? String(toolResult.content) : '',
+            content: toolResult.content,
             tool_call_id: toolResult.tool_use_id,
           };
         }
       }
 
-      // Map assistant messages with tool_calls
       if (msg.role === 'assistant' && msg.tool_calls && msg.tool_calls.length > 0) {
         return {
           role: 'assistant' as const,
-          content: content! || null,
+          content: content || null,
           tool_calls: msg.tool_calls.map((tc) => ({
             id: tc.id,
             type: 'function' as const,
@@ -76,7 +67,7 @@ export class OpenAIProvider implements AIProvider {
 
       return {
         role: msg.role as 'system' | 'user' | 'assistant',
-        content: content!,
+        content,
       };
     });
 
@@ -105,12 +96,7 @@ export class OpenAIProvider implements AIProvider {
             arguments: JSON.parse(tc.function.arguments),
           };
           toolCalls.push(toolCall);
-          contentBlocks.push({
-            type: 'tool_use',
-            id: toolCall.id,
-            name: toolCall.name,
-            input: toolCall.arguments,
-          });
+          contentBlocks.push(buildToolCallContentBlock(toolCall));
         }
       }
 
@@ -118,12 +104,7 @@ export class OpenAIProvider implements AIProvider {
         : choice.finish_reason === 'length' ? 'max_tokens'
         : 'end_turn';
 
-      return {
-        text: msg.content || '',
-        contentBlocks,
-        toolCalls,
-        stopReason,
-      };
+      return { text: msg.content || '', contentBlocks, toolCalls, stopReason };
     } catch (error: any) {
       log.error({ err: error, model }, 'chatCompletion failed');
       throw new Error(`OpenAI chat completion failed: ${error.message}`);
@@ -150,4 +131,25 @@ export class OpenAIProvider implements AIProvider {
       throw new Error(`OpenAI image analysis failed: ${error.message}`);
     }
   }
+}
+
+const CAPABILITIES: ProviderCapabilities = {
+  chatCompletion: true,
+  streaming: true,
+  imageAnalysis: true,
+};
+
+export function register(): ProviderRegistration {
+  return {
+    name: 'openai',
+    models: [
+      { key: 'openai', provider: 'openai', model: 'gpt-4o-mini', displayName: 'GPT-4o Mini', capabilities: CAPABILITIES },
+    ],
+    capabilities: CAPABILITIES,
+    factory: (modelId: string) => {
+      const apiKey = process.env.OPENAI_API_KEY;
+      if (!apiKey) throw new Error('OPENAI_API_KEY not configured');
+      return new OpenAIProvider(apiKey, modelId);
+    },
+  };
 }

--- a/backend/src/providers/types.ts
+++ b/backend/src/providers/types.ts
@@ -14,32 +14,26 @@ export interface AIProvider {
   readonly name: string;
   readonly capabilities: ProviderCapabilities;
 
-  /**
-   * Chat completion with optional tool calling.
-   * All providers must implement this — providers without native chat
-   * adapt textCompletion into this interface.
-   */
   chatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResult>;
-
-  /**
-   * Text completion (streaming). Returns a Node.js readable stream
-   * of { text: string, done: boolean } chunks.
-   * Optional — only for providers that support streaming.
-   */
   textCompletion?(prompt: string): Promise<NodeJS.ReadableStream>;
-
-  /**
-   * Image analysis. Returns text description of the image.
-   * Optional — only for providers that support vision.
-   */
   imageAnalysis?(imageUrl: string, prompt?: string): Promise<string>;
 }
 
 // ─── Model Registry ───
 
 export interface ModelConfig {
+  key?: string;
   provider: string;
   model: string;
   displayName: string;
   capabilities: ProviderCapabilities;
+}
+
+// ─── Provider Registration (auto-registration pattern) ───
+
+export interface ProviderRegistration {
+  name: string;
+  models: ModelConfig[];
+  capabilities: ProviderCapabilities;
+  factory: (modelId: string) => AIProvider;
 }

--- a/backend/src/providers/utils.ts
+++ b/backend/src/providers/utils.ts
@@ -1,0 +1,32 @@
+import { ContentBlock, ContentBlockParam, ToolUseBlock } from '../types/content';
+import { ToolCall } from '../types/messages';
+
+export function extractTextContent(
+  content: string | (ContentBlock | ContentBlockParam)[],
+): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join(' ');
+}
+
+export function mapToolResult(
+  content: (ContentBlock | ContentBlockParam)[],
+): { tool_use_id: string; content: string } | null {
+  const block = content.find((b) => b.type === 'tool_result');
+  if (!block || !('tool_use_id' in block)) return null;
+  return {
+    tool_use_id: block.tool_use_id,
+    content: 'content' in block ? String(block.content) : '',
+  };
+}
+
+export function buildToolCallContentBlock(toolCall: ToolCall): ToolUseBlock {
+  return {
+    type: 'tool_use',
+    id: toolCall.id,
+    name: toolCall.name,
+    input: toolCall.arguments,
+  };
+}

--- a/backend/src/routes/messageRoutes.ts
+++ b/backend/src/routes/messageRoutes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { asyncHandler } from '../middleware/asyncHandler';
 import {
   handleSendMessage,
   handleGetMessages,
@@ -6,7 +7,7 @@ import {
 
 const router = Router();
 
-router.post('/threads/:id/messages', handleSendMessage);
-router.get('/threads/:id/messages', handleGetMessages);
+router.post('/threads/:id/messages', asyncHandler(handleSendMessage));
+router.get('/threads/:id/messages', asyncHandler(handleGetMessages));
 
 export { router as messageRoutes };

--- a/backend/src/routes/threadRoutes.ts
+++ b/backend/src/routes/threadRoutes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { asyncHandler } from '../middleware/asyncHandler';
 import {
   handleCreateThread,
   handleListThreads,
@@ -9,10 +10,10 @@ import {
 
 const router = Router();
 
-router.post('/threads', handleCreateThread);
-router.get('/threads', handleListThreads);
-router.get('/threads/:id', handleGetThread);
-router.patch('/threads/:id', handleUpdateThread);
-router.delete('/threads/:id', handleDeleteThread);
+router.post('/threads', asyncHandler(handleCreateThread));
+router.get('/threads', asyncHandler(handleListThreads));
+router.get('/threads/:id', asyncHandler(handleGetThread));
+router.patch('/threads/:id', asyncHandler(handleUpdateThread));
+router.delete('/threads/:id', asyncHandler(handleDeleteThread));
 
 export { router as threadRoutes };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,11 +8,12 @@ import { threadRoutes } from './routes/threadRoutes';
 import { messageRoutes } from './routes/messageRoutes';
 import { registerAllTools } from './tools';
 import { toolRegistry } from './services/toolRegistry';
+import { registerProviders } from './providers';
 import logger from './config/logger';
 
 dotenv.config();
 
-// Register all available tools
+registerProviders();
 registerAllTools();
 logger.info({ tools: toolRegistry.getDefinitions().map(t => t.name) }, 'Tools registered');
 

--- a/backend/src/services/chatService.ts
+++ b/backend/src/services/chatService.ts
@@ -4,45 +4,10 @@ import { toolRegistry } from './toolRegistry';
 import { runAgenticLoop, AgenticLoopCallbacks, AgenticLoopResult } from './toolExecutor';
 import { ContentBlockParam } from '../types/content';
 import { contextService } from './contextService';
+import { getSystemPrompt } from '../prompts';
 import logger from '../config/logger';
 
 const log = logger.child({ service: 'chat' });
-
-const SYSTEM_PROMPT = `You are a helpful AI assistant with tools. Current date: ${new Date().toISOString().split('T')[0]}. User timezone: Asia/Dhaka (UTC+6).
-
-CRITICAL RULES - FOLLOW EXACTLY:
-
-1. NEVER use your training data for current information (news, events, weather, calendar, stock prices, sports scores)
-
-2. For ANY current/real-time query, you MUST use the appropriate tool:
-   - Current date/time → get_current_date
-   - News/current events → web_search
-   - Calendar/schedule → google_calendar
-   - Websites/URLs → fetch_url
-   - Math calculations → calculator
-
-3. When a tool returns results, you MUST synthesize them into a helpful answer:
-   - web_search → Read ALL results, filter relevant ones, write a natural summary (NOT a numbered list)
-   - Focus on the most important/recent information
-   - Ignore irrelevant results (off-topic, different languages, spam)
-   - Write in complete sentences, provide context
-   - NEVER say "I don't have access" after receiving tool results
-
-4. ONLY say "I don't have access to [X]" if:
-   - You tried a tool and it FAILED with an error
-   - No tool exists for the request
-
-5. Answer directly from tool results - no filler, no explaining your process
-
-CRITICAL: If you just called a tool and received results, those results are REAL and CURRENT. Use them in your answer. DO NOT claim you don't have access after successfully calling a tool. The tool output is your source of truth.
-
-Example:
-- User: "What's on my calendar?"
-- You call google_calendar → Returns: "Meeting at 2pm"
-- CORRECT response: "You have a meeting at 2pm"
-- WRONG response: "I don't have access to your calendar" (YOU JUST ACCESSED IT!)
-
-REMEMBER: If you call a tool and it succeeds, you MUST use its results in your response. Don't ignore successful tool outputs.`;
 
 export interface ChatResult {
   text: string;
@@ -50,12 +15,7 @@ export interface ChatResult {
   durationMs: number;
 }
 
-// Models that don't support tool calling (should use simple prompt)
 const NO_TOOL_MODELS = ['gemma'];
-
-const SIMPLE_PROMPT = `You are a helpful AI assistant. Current date: ${new Date().toISOString().split('T')[0]}. User timezone: Asia/Dhaka (UTC+6).
-
-Answer questions directly and concisely based on your knowledge. If you don't know current information (today's news, live events, real-time data), say "I don't have access to current [X]" - don't make up answers.`;
 
 export async function processMessage(
   thread: Thread,
@@ -66,10 +26,6 @@ export async function processMessage(
   const provider = createProvider(thread.model);
   const allTools = toolRegistry.getDefinitions();
 
-  // Filter tools based on selection
-  // - undefined: use all tools (backward compatibility)
-  // - empty array: no tools (user disabled all)
-  // - array with items: use selected tools only
   const tools = selectedToolNames === undefined
     ? allTools
     : selectedToolNames.length > 0
@@ -83,34 +39,24 @@ export async function processMessage(
     provider: provider.name,
     totalTools: allTools.length,
     selectedTools: tools.length,
-    toolNames: tools.map(t => t.name)
+    toolNames: tools.map(t => t.name),
   }, 'Processing message');
 
-  // Build message history using contextService (with token budgeting and caching)
   const messages = await contextService.buildContextWindow(thread.id);
 
-  log.debug({
-    contextMessages: messages.map(m => ({
-      role: m.role,
-      contentPreview: typeof m.content === 'string' ? m.content.substring(0, 100) : JSON.stringify(m.content).substring(0, 100)
-    }))
-  }, 'Context loaded');
-
-  // Use simple prompt for models that don't support tools OR when no tools are available
   const supportsTools = !NO_TOOL_MODELS.some((m) => thread.model.includes(m));
   const hasTools = tools.length > 0;
   const useToolPrompt = supportsTools && hasTools;
-  const systemPrompt = useToolPrompt ? SYSTEM_PROMPT : SIMPLE_PROMPT;
+
+  const systemPrompt = getSystemPrompt({ supportsTools: useToolPrompt });
   messages.unshift({ role: 'system', content: systemPrompt });
 
   log.debug({
     finalMessageCount: messages.length,
     roles: messages.map(m => m.role),
-    usingToolPrompt: useToolPrompt
+    usingToolPrompt: useToolPrompt,
   }, 'Messages prepared for LLM');
 
-  // All providers now implement chatCompletion — use the agentic loop
-  // Only pass tools to models that support them AND when tools are available
   const effectiveTools = useToolPrompt ? tools : [];
   const loopResult = await runAgenticLoop(provider, messages, effectiveTools, callbacks);
 

--- a/backend/src/services/contextService.ts
+++ b/backend/src/services/contextService.ts
@@ -1,5 +1,6 @@
 import prisma from '../config/database';
 import { MessageParam } from '../types/messages';
+import { extractTextContent } from '../providers/utils';
 import logger from '../config/logger';
 
 const log = logger.child({ service: 'contextService' });
@@ -14,95 +15,25 @@ export class ContextService {
   private ttlMs = 10 * 60 * 1000; // 10 minutes
 
   async buildContextWindow(threadId: string, maxTokens = 100_000): Promise<MessageParam[]> {
-    // Check cache
-    const cached = this.cache.get(threadId);
-    if (cached && Date.now() - cached.timestamp < this.ttlMs) {
-      log.debug({ threadId, messageCount: cached.messages.length }, 'Context cache hit');
-      return cached.messages;
-    }
+    const cached = this.lookupCache(threadId);
+    if (cached) return cached;
 
-    // Fetch from DB (newest first)
-    const dbMessages = await prisma.message.findMany({
-      where: { threadId, status: 'complete' },
-      orderBy: { createdAt: 'desc' },
-      take: 100,
-    });
+    const chronological = await this.fetchMessages(threadId);
+    if (chronological.length === 0) return [];
 
-    log.debug({
-      threadId,
-      dbMessageCount: dbMessages.length,
-      messages: dbMessages.map(m => ({
-        id: m.id,
-        role: m.role,
-        contentType: typeof m.content,
-        contentPreview: JSON.stringify(m.content).substring(0, 150)
-      }))
-    }, 'Messages fetched from DB');
+    const window = this.applyTokenBudget(chronological, maxTokens);
+    const merged = this.enforceMinimumMessages(window, chronological);
 
-    if (dbMessages.length === 0) return [];
-
-    // Reverse to chronological order
-    const chronological = dbMessages.reverse();
-
-    // Token budget: walk from newest, keep what fits
-    const reserveForCompletion = 4096;
-    let budget = maxTokens - reserveForCompletion;
-    const window: typeof chronological = [];
-
-    for (const msg of [...chronological].reverse()) {
-      const text = this.extractText(msg.content as any[]);
-      const tokens = this.estimateTokens(text);
-      if (budget - tokens < 0) break;
-      window.unshift(msg);
-      budget -= tokens;
-    }
-
-    // Safety floor: always include at least the last 4 messages
-    const minMessages = chronological.slice(-4);
-    const merged = this.dedupeById([...window, ...minMessages]);
-
-    // Convert to MessageParam[] format
     const rawMessages: MessageParam[] = merged.map((m) => ({
       role: m.role as MessageParam['role'],
-      content: typeof m.content === 'string'
-        ? m.content
-        : (m.content as any[])
-            .filter((b: any) => b.type === 'text')
-            .map((b: any) => b.text)
-            .join(' '),
+      content: extractTextContent(
+        typeof m.content === 'string' ? m.content : (m.content as any[]),
+      ),
     }));
 
-    // Enforce role alternation (user → assistant → user)
-    // Remove consecutive messages with the same role
-    const messages: MessageParam[] = [];
-    for (let i = 0; i < rawMessages.length; i++) {
-      const current = rawMessages[i];
-      const previous = messages[messages.length - 1];
+    const messages = this.enforceRoleAlternation(rawMessages, threadId);
+    this.validateLastRole(messages, threadId);
 
-      if (!previous || previous.role !== current.role) {
-        messages.push(current);
-      } else {
-        // Skip consecutive same-role messages (merge or ignore)
-        const contentPreview = typeof current.content === 'string'
-          ? current.content.substring(0, 50)
-          : String(current.content).substring(0, 50);
-        log.warn({
-          threadId,
-          skippedRole: current.role,
-          skippedContent: contentPreview,
-        }, 'Skipped consecutive message with same role');
-      }
-    }
-
-    // Ensure last message is from user (required by LLM APIs)
-    if (messages.length > 0 && messages[messages.length - 1].role !== 'user') {
-      log.warn({
-        threadId,
-        lastRole: messages[messages.length - 1].role,
-      }, 'Last message is not from user - this may cause LLM errors');
-    }
-
-    // Calculate token usage
     const totalTokens = messages.reduce((sum, m) => {
       const text = typeof m.content === 'string' ? m.content : String(m.content);
       return sum + this.estimateTokens(text);
@@ -111,7 +42,7 @@ export class ContextService {
     log.info(
       {
         threadId,
-        totalMessages: dbMessages.length,
+        totalMessages: chronological.length,
         includedMessages: messages.length,
         estimatedTokens: totalTokens,
         tokenBudget: maxTokens - 4096,
@@ -119,9 +50,7 @@ export class ContextService {
       'Context window built',
     );
 
-    // Cache
     this.cache.set(threadId, { messages, timestamp: Date.now() });
-
     return messages;
   }
 
@@ -134,17 +63,76 @@ export class ContextService {
   }
 
   estimateTokens(text: string): number {
-    // ~4 chars per token (rough estimate)
-    // TODO: Use tiktoken for accurate counting
     return Math.ceil(text.length / 4);
   }
 
+  private lookupCache(threadId: string): MessageParam[] | null {
+    const cached = this.cache.get(threadId);
+    if (cached && Date.now() - cached.timestamp < this.ttlMs) {
+      log.debug({ threadId, messageCount: cached.messages.length }, 'Context cache hit');
+      return cached.messages;
+    }
+    return null;
+  }
+
+  private async fetchMessages(threadId: string) {
+    const dbMessages = await prisma.message.findMany({
+      where: { threadId, status: 'complete' },
+      orderBy: { createdAt: 'desc' },
+      take: 100,
+    });
+
+    log.debug({ threadId, dbMessageCount: dbMessages.length }, 'Messages fetched from DB');
+    return dbMessages.reverse();
+  }
+
+  private applyTokenBudget(chronological: any[], maxTokens: number): any[] {
+    const reserveForCompletion = 4096;
+    let budget = maxTokens - reserveForCompletion;
+    const window: any[] = [];
+
+    for (const msg of [...chronological].reverse()) {
+      const text = this.extractText(msg.content as any[]);
+      const tokens = this.estimateTokens(text);
+      if (budget - tokens < 0) break;
+      window.unshift(msg);
+      budget -= tokens;
+    }
+
+    return window;
+  }
+
+  private enforceMinimumMessages(window: any[], allMessages: any[]): any[] {
+    const minMessages = allMessages.slice(-4);
+    return this.dedupeById([...window, ...minMessages]);
+  }
+
+  private enforceRoleAlternation(rawMessages: MessageParam[], threadId: string): MessageParam[] {
+    const messages: MessageParam[] = [];
+    for (const current of rawMessages) {
+      const previous = messages[messages.length - 1];
+      if (!previous || previous.role !== current.role) {
+        messages.push(current);
+      } else {
+        const contentPreview = typeof current.content === 'string'
+          ? current.content.substring(0, 50)
+          : String(current.content).substring(0, 50);
+        log.warn({ threadId, skippedRole: current.role, skippedContent: contentPreview },
+          'Skipped consecutive message with same role');
+      }
+    }
+    return messages;
+  }
+
+  private validateLastRole(messages: MessageParam[], threadId: string): void {
+    if (messages.length > 0 && messages[messages.length - 1].role !== 'user') {
+      log.warn({ threadId, lastRole: messages[messages.length - 1].role },
+        'Last message is not from user - this may cause LLM errors');
+    }
+  }
+
   private extractText(content: any[]): string {
-    if (!Array.isArray(content)) return String(content);
-    return content
-      .filter((b) => b.type === 'text')
-      .map((b) => b.text)
-      .join(' ');
+    return extractTextContent(content);
   }
 
   private dedupeById(messages: any[]): any[] {
@@ -157,6 +145,4 @@ export class ContextService {
   }
 }
 
-// Singleton instance
-// TODO: Replace with Redis-backed cache for horizontal scaling
 export const contextService = new ContextService();

--- a/backend/src/services/threadService.ts
+++ b/backend/src/services/threadService.ts
@@ -1,5 +1,6 @@
 import prisma from '../config/database';
 import { Thread } from '@prisma/client';
+import { NotFoundError } from '../errors';
 
 export async function createThread(
   userId: string,
@@ -43,7 +44,7 @@ export async function updateThread(
   data: { title?: string; status?: string; systemPrompt?: string },
 ): Promise<Thread> {
   const thread = await getThreadById(threadId, userId);
-  if (!thread) throw new Error('Thread not found');
+  if (!thread) throw new NotFoundError('Thread not found');
 
   const updateData: Record<string, unknown> = {};
   if (data.title !== undefined) updateData.title = data.title;
@@ -61,4 +62,14 @@ export async function softDeleteThread(
   userId: string,
 ): Promise<Thread> {
   return updateThread(threadId, userId, { status: 'deleted' });
+}
+
+export async function incrementThreadTokens(
+  threadId: string,
+  delta: number,
+): Promise<void> {
+  await prisma.thread.update({
+    where: { id: threadId },
+    data: { tokenCount: { increment: delta } },
+  });
 }

--- a/backend/src/services/toolExecutor.ts
+++ b/backend/src/services/toolExecutor.ts
@@ -84,26 +84,25 @@ export async function runAgenticLoop(
     // 4. Execute ALL tool calls in parallel (Anthropic pattern)
     const toolCallPromises = response.toolCalls.map(async (toolCall): Promise<ToolCallRecord> => {
       callbacks.onToolUseStart(toolCall);
-      log.info({ tool: toolCall.name, input: toolCall.arguments }, 'Tool call start');
+      const inputSize = JSON.stringify(toolCall.arguments).length;
+      log.info({ tool: toolCall.name, inputSize }, 'Tool call start');
 
       const start = Date.now();
       const result = await toolRegistry.execute(toolCall.name, toolCall.arguments);
       const durationMs = Date.now() - start;
 
-      // Truncate output if too large
       if (result.output.length > MAX_TOOL_OUTPUT_LENGTH) {
         log.warn({ tool: toolCall.name, originalLength: result.output.length }, 'Tool output truncated');
         result.output = result.output.substring(0, MAX_TOOL_OUTPUT_LENGTH) + '\n\n[Output truncated]';
       }
 
-      // Log tool output for debugging summarization
-      log.debug({
+      log.info({
         tool: toolCall.name,
-        outputPreview: result.output.substring(0, 500),
-        outputLength: result.output.length
-      }, 'Tool output preview');
-
-      log.info({ tool: toolCall.name, durationMs, is_error: result.is_error }, 'Tool call end');
+        durationMs,
+        inputSize,
+        outputSize: result.output.length,
+        success: !result.is_error,
+      }, 'Tool call end');
       callbacks.onToolUseResult(toolCall.id, toolCall.name, result);
 
       return { call: toolCall, result, durationMs };

--- a/backend/src/sse/sseWriter.ts
+++ b/backend/src/sse/sseWriter.ts
@@ -1,0 +1,83 @@
+import { Response } from 'express';
+import {
+  MessageStartEvent,
+  DeltaEvent,
+  ToolUseStartEvent,
+  ToolUseResultEvent,
+  MessageStopEvent,
+  ErrorEvent,
+} from './types';
+
+export class SSEWriter {
+  private closed = false;
+
+  constructor(private readonly res: Response) {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+
+    res.on('close', () => {
+      this.closed = true;
+    });
+  }
+
+  sendMessageStart(data: Omit<MessageStartEvent, 'type'>): void {
+    this.write({ type: 'message_start', ...data });
+  }
+
+  sendDelta(text: string): void {
+    const event: DeltaEvent = {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    };
+    this.write(event);
+  }
+
+  sendToolUseStart(data: Omit<ToolUseStartEvent, 'type' | 'index'>['content_block']): void {
+    const event: ToolUseStartEvent = {
+      type: 'content_block_start',
+      index: 0,
+      content_block: data,
+    };
+    this.write(event);
+  }
+
+  sendToolUseResult(data: Omit<ToolUseResultEvent, 'type' | 'index'>['tool_result']): void {
+    const event: ToolUseResultEvent = {
+      type: 'content_block_stop',
+      index: 0,
+      tool_result: data,
+    };
+    this.write(event);
+  }
+
+  sendMessageStop(stopReason: string, toolCallsCount: number): void {
+    const event: MessageStopEvent = {
+      type: 'message_stop',
+      stop_reason: stopReason,
+      tool_calls_count: toolCallsCount,
+    };
+    this.write(event);
+  }
+
+  sendError(data: ErrorEvent['error']): void {
+    this.write({ type: 'error', error: data });
+  }
+
+  end(): void {
+    if (!this.closed) {
+      this.closed = true;
+      this.res.end();
+    }
+  }
+
+  get isOpen(): boolean {
+    return !this.closed;
+  }
+
+  private write(payload: object): void {
+    if (this.closed) return;
+    this.res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  }
+}

--- a/backend/src/sse/types.ts
+++ b/backend/src/sse/types.ts
@@ -1,0 +1,54 @@
+// ─── SSE Event Types for POST /api/v1/threads/:id/messages ───
+
+export interface MessageStartEvent {
+  type: 'message_start';
+  message_id: string;
+  assistant_msg_id: string;
+  user_msg_id: string;
+}
+
+export interface DeltaEvent {
+  type: 'content_block_delta';
+  index: number;
+  delta: {
+    type: 'text_delta';
+    text: string;
+  };
+}
+
+export interface ToolUseStartEvent {
+  type: 'content_block_start';
+  index: number;
+  content_block: {
+    type: 'tool_use';
+    id: string;
+    name: string;
+    input: Record<string, unknown>;
+  };
+}
+
+export interface ToolUseResultEvent {
+  type: 'content_block_stop';
+  index: number;
+  tool_result: {
+    tool_call_id: string;
+    name: string;
+    output: string;
+    is_error: boolean;
+  };
+}
+
+export interface MessageStopEvent {
+  type: 'message_stop';
+  stop_reason: string;
+  tool_calls_count: number;
+}
+
+export interface ErrorEvent {
+  type: 'error';
+  error: {
+    type: string;
+    message: string;
+    retryable: boolean;
+  };
+}

--- a/backend/src/types/events.ts
+++ b/backend/src/types/events.ts
@@ -1,18 +1,27 @@
+export {
+  MessageStartEvent,
+  DeltaEvent,
+  ToolUseStartEvent,
+  ToolUseResultEvent,
+  MessageStopEvent,
+  ErrorEvent,
+} from '../sse/types';
+
 import { ContentBlock } from './content';
 import { StopReason } from './messages';
 
-// ─── SSE Stream Events (Anthropic-style granular events) ───
+// ─── Legacy SSE Stream Events (kept for backward compatibility) ───
 
 export type StreamEvent =
-  | MessageStartEvent
+  | LegacyMessageStartEvent
   | ContentBlockStartEvent
   | ContentBlockDeltaEvent
   | ContentBlockStopEvent
   | MessageDeltaEvent
-  | MessageStopEvent
+  | LegacyMessageStopEvent
   | StreamErrorEvent;
 
-export interface MessageStartEvent {
+export interface LegacyMessageStartEvent {
   type: 'message_start';
   message_id: string;
   assistant_msg_id: string;
@@ -52,7 +61,7 @@ export interface MessageDeltaEvent {
   tool_calls_count: number;
 }
 
-export interface MessageStopEvent {
+export interface LegacyMessageStopEvent {
   type: 'message_stop';
 }
 

--- a/backend/tests/controllers/messageController.test.ts
+++ b/backend/tests/controllers/messageController.test.ts
@@ -1,5 +1,6 @@
 const mockThreadService = {
   getThreadById: jest.fn(),
+  incrementThreadTokens: jest.fn(),
 };
 
 const mockMessageService = {
@@ -7,7 +8,6 @@ const mockMessageService = {
   getByThread: jest.fn(),
   updateMessageStatus: jest.fn(),
   countByThread: jest.fn(),
-  incrementThreadTokens: jest.fn(),
 };
 
 const mockContextService = {
@@ -40,12 +40,14 @@ jest.mock('../../src/config/database', () => ({
 import request from 'supertest';
 import express from 'express';
 import { authMiddleware } from '../../src/middleware/auth';
+import { errorHandler } from '../../src/middleware/errorHandler';
 import { messageRoutes } from '../../src/routes/messageRoutes';
 
 const app = express();
 app.use(express.json());
 app.use(authMiddleware);
 app.use('/api/v1', messageRoutes);
+app.use(errorHandler);
 
 const USER_ID = '00000000-0000-0000-0000-000000000001';
 

--- a/backend/tests/controllers/threadController.test.ts
+++ b/backend/tests/controllers/threadController.test.ts
@@ -17,12 +17,14 @@ jest.mock('../../src/services/messageService', () => mockMessageService);
 import request from 'supertest';
 import express from 'express';
 import { authMiddleware } from '../../src/middleware/auth';
+import { errorHandler } from '../../src/middleware/errorHandler';
 import { threadRoutes } from '../../src/routes/threadRoutes';
 
 const app = express();
 app.use(express.json());
 app.use(authMiddleware);
 app.use('/api/v1', threadRoutes);
+app.use(errorHandler);
 
 const USER_ID = '00000000-0000-0000-0000-000000000001';
 

--- a/backend/tests/providers/utils.test.ts
+++ b/backend/tests/providers/utils.test.ts
@@ -1,0 +1,85 @@
+import { extractTextContent, mapToolResult, buildToolCallContentBlock } from '../../src/providers/utils';
+
+describe('extractTextContent', () => {
+  it('returns string content directly', () => {
+    expect(extractTextContent('hello world')).toBe('hello world');
+  });
+
+  it('extracts text from content blocks', () => {
+    const content = [
+      { type: 'text' as const, text: 'hello' },
+      { type: 'text' as const, text: 'world' },
+    ];
+    expect(extractTextContent(content)).toBe('hello world');
+  });
+
+  it('filters out non-text blocks', () => {
+    const content = [
+      { type: 'text' as const, text: 'hello' },
+      { type: 'tool_use' as const, id: '1', name: 'calc', input: {} },
+      { type: 'text' as const, text: 'world' },
+    ];
+    expect(extractTextContent(content)).toBe('hello world');
+  });
+
+  it('returns empty string for empty array', () => {
+    expect(extractTextContent([])).toBe('');
+  });
+
+  it('passes through unknown content block types without error', () => {
+    const content: any[] = [
+      { type: 'text', text: 'hello' },
+      { type: 'unknown_future_type', data: 'something' },
+    ];
+    expect(extractTextContent(content)).toBe('hello');
+  });
+});
+
+describe('mapToolResult', () => {
+  it('extracts tool result from content blocks', () => {
+    const content = [
+      { type: 'tool_result' as const, tool_use_id: 'call_1', content: 'result text', is_error: false },
+    ];
+    expect(mapToolResult(content)).toEqual({
+      tool_use_id: 'call_1',
+      content: 'result text',
+    });
+  });
+
+  it('returns null when no tool_result block exists', () => {
+    const content = [{ type: 'text' as const, text: 'hello' }];
+    expect(mapToolResult(content)).toBeNull();
+  });
+
+  it('returns empty content string when content field is missing', () => {
+    const content = [
+      { type: 'tool_result' as const, tool_use_id: 'call_1' } as any,
+    ];
+    expect(mapToolResult(content)).toEqual({
+      tool_use_id: 'call_1',
+      content: '',
+    });
+  });
+});
+
+describe('buildToolCallContentBlock', () => {
+  it('creates a tool_use content block from a ToolCall', () => {
+    const toolCall = { id: 'call_1', name: 'calculator', arguments: { expression: '2+2' } };
+    expect(buildToolCallContentBlock(toolCall)).toEqual({
+      type: 'tool_use',
+      id: 'call_1',
+      name: 'calculator',
+      input: { expression: '2+2' },
+    });
+  });
+
+  it('handles empty arguments', () => {
+    const toolCall = { id: 'call_2', name: 'list_tools', arguments: {} };
+    expect(buildToolCallContentBlock(toolCall)).toEqual({
+      type: 'tool_use',
+      id: 'call_2',
+      name: 'list_tools',
+      input: {},
+    });
+  });
+});

--- a/backend/tests/sse/sseWriter.test.ts
+++ b/backend/tests/sse/sseWriter.test.ts
@@ -1,0 +1,132 @@
+import { SSEWriter } from '../../src/sse/sseWriter';
+import { EventEmitter } from 'events';
+
+function createMockResponse() {
+  const emitter = new EventEmitter();
+  const written: string[] = [];
+  const headers: Record<string, string> = {};
+  let ended = false;
+
+  const res = {
+    setHeader: jest.fn((key: string, value: string) => { headers[key] = value; }),
+    write: jest.fn((data: string) => { written.push(data); return true; }),
+    end: jest.fn(() => { ended = true; }),
+    on: emitter.on.bind(emitter),
+  };
+
+  return {
+    res: res as any,
+    emitter,
+    written,
+    headers,
+    isEnded: () => ended,
+  };
+}
+
+describe('SSEWriter', () => {
+  it('sets SSE headers on construction', () => {
+    const { res } = createMockResponse();
+    new SSEWriter(res);
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
+    expect(res.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
+  });
+
+  it('sends message_start event', () => {
+    const { res, written } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.sendMessageStart({ message_id: 'm1', assistant_msg_id: 'a1', user_msg_id: 'u1' });
+    expect(written).toHaveLength(1);
+    const parsed = JSON.parse(written[0].replace('data: ', '').trim());
+    expect(parsed).toEqual({
+      type: 'message_start',
+      message_id: 'm1',
+      assistant_msg_id: 'a1',
+      user_msg_id: 'u1',
+    });
+  });
+
+  it('sends delta event', () => {
+    const { res, written } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.sendDelta('hello');
+    const parsed = JSON.parse(written[0].replace('data: ', '').trim());
+    expect(parsed).toEqual({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'hello' },
+    });
+  });
+
+  it('sends tool_use_start event', () => {
+    const { res, written } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.sendToolUseStart({ type: 'tool_use', id: 'c1', name: 'calc', input: { x: 1 } });
+    const parsed = JSON.parse(written[0].replace('data: ', '').trim());
+    expect(parsed.type).toBe('content_block_start');
+    expect(parsed.content_block.name).toBe('calc');
+  });
+
+  it('sends tool_use_result event', () => {
+    const { res, written } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.sendToolUseResult({ tool_call_id: 'c1', name: 'calc', output: '4', is_error: false });
+    const parsed = JSON.parse(written[0].replace('data: ', '').trim());
+    expect(parsed.type).toBe('content_block_stop');
+    expect(parsed.tool_result.output).toBe('4');
+  });
+
+  it('sends message_stop event', () => {
+    const { res, written } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.sendMessageStop('end_turn', 0);
+    const parsed = JSON.parse(written[0].replace('data: ', '').trim());
+    expect(parsed).toEqual({
+      type: 'message_stop',
+      stop_reason: 'end_turn',
+      tool_calls_count: 0,
+    });
+  });
+
+  it('sends error event', () => {
+    const { res, written } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.sendError({ type: 'internal_error', message: 'oops', retryable: true });
+    const parsed = JSON.parse(written[0].replace('data: ', '').trim());
+    expect(parsed.type).toBe('error');
+    expect(parsed.error.message).toBe('oops');
+  });
+
+  it('does not write after end() is called', () => {
+    const { res, written } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.end();
+    writer.sendDelta('should not appear');
+    expect(written).toHaveLength(0);
+    expect(res.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write after client disconnects', () => {
+    const { res, written, emitter } = createMockResponse();
+    const writer = new SSEWriter(res);
+    emitter.emit('close');
+    writer.sendDelta('should not appear');
+    expect(written).toHaveLength(0);
+  });
+
+  it('end() is idempotent', () => {
+    const { res } = createMockResponse();
+    const writer = new SSEWriter(res);
+    writer.end();
+    writer.end();
+    expect(res.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports connection state via isOpen', () => {
+    const { res, emitter } = createMockResponse();
+    const writer = new SSEWriter(res);
+    expect(writer.isOpen).toBe(true);
+    emitter.emit('close');
+    expect(writer.isOpen).toBe(false);
+  });
+});

--- a/specs/002-backend-refactor/checklists/requirements.md
+++ b/specs/002-backend-refactor/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Backend Architecture Refactor
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit-clarify` or `/speckit-plan`.
+- The spec references specific file names (messageController.ts, chatService.ts, etc.) for context — these describe the current state, not the implementation approach.

--- a/specs/002-backend-refactor/contracts/sse-events.md
+++ b/specs/002-backend-refactor/contracts/sse-events.md
@@ -1,0 +1,125 @@
+# SSE Event Contract
+
+**Feature**: 002-backend-refactor | **Date**: 2026-06-10
+
+> This contract documents the SSE event format for `POST /api/v1/threads/:id/messages`. These event shapes MUST NOT change during the refactor (FR-009).
+
+## Transport
+
+- Content-Type: `text/event-stream`
+- Cache-Control: `no-cache`
+- Connection: `keep-alive`
+- Each event is formatted as: `data: {JSON}\n\n`
+
+## Event Sequence
+
+```
+message_start → (content_block_delta)* → (content_block_start → content_block_stop)* → message_stop
+                                                                                        ↑ or error at any point
+```
+
+A typical no-tool response:
+```
+message_start → content_block_delta (repeated) → message_stop
+```
+
+A tool-calling response:
+```
+message_start → content_block_delta* → content_block_start → content_block_stop → content_block_delta* → message_stop
+```
+
+## Event Definitions
+
+### message_start
+Emitted once at the beginning of every response.
+
+```json
+{
+  "type": "message_start",
+  "message_id": "uuid",
+  "assistant_msg_id": "uuid",
+  "user_msg_id": "uuid"
+}
+```
+
+### content_block_delta
+Emitted for each text chunk from the AI provider. May occur zero or more times.
+
+```json
+{
+  "type": "content_block_delta",
+  "index": 0,
+  "delta": {
+    "type": "text_delta",
+    "text": "chunk of text"
+  }
+}
+```
+
+### content_block_start
+Emitted when a tool call begins. Contains the tool name and parsed arguments.
+
+```json
+{
+  "type": "content_block_start",
+  "index": 0,
+  "content_block": {
+    "type": "tool_use",
+    "id": "call_id",
+    "name": "tool_name",
+    "input": { "key": "value" }
+  }
+}
+```
+
+### content_block_stop
+Emitted when a tool call completes. Contains the tool result.
+
+```json
+{
+  "type": "content_block_stop",
+  "index": 0,
+  "tool_result": {
+    "tool_call_id": "call_id",
+    "name": "tool_name",
+    "output": "result text",
+    "is_error": false
+  }
+}
+```
+
+### message_stop
+Emitted once when the response is complete (after all tool loops resolve).
+
+```json
+{
+  "type": "message_stop",
+  "stop_reason": "end_turn",
+  "tool_calls_count": 0
+}
+```
+
+`stop_reason` values: `"end_turn"`, `"max_tokens"`, `"tool_use"` (internal, not normally seen by client).
+
+### error
+Emitted if an error occurs at any point during processing. May be followed by stream close.
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "internal_error",
+    "message": "human-readable error message",
+    "retryable": true
+  }
+}
+```
+
+## Invariants
+
+1. Every stream starts with exactly one `message_start` event.
+2. Every successful stream ends with exactly one `message_stop` event.
+3. `content_block_start` is always followed by a matching `content_block_stop` for the same tool call.
+4. `content_block_delta` events may interleave with tool call events (text → tool → more text).
+5. The `index` field is always `0` (reserved for future multi-block support).
+6. All JSON payloads are valid, non-nested objects (no streaming partial JSON).

--- a/specs/002-backend-refactor/data-model.md
+++ b/specs/002-backend-refactor/data-model.md
@@ -1,0 +1,138 @@
+# Data Model: Backend Architecture Refactor
+
+**Feature**: 002-backend-refactor | **Date**: 2026-06-10
+
+> No database schema changes. This document describes the **code-level entities** being refactored — interfaces, registries, and abstractions.
+
+## Entities
+
+### AIProvider (interface — refactored)
+
+**Location**: `backend/src/providers/types.ts`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Provider identifier (e.g., `'openai'`, `'google'`, `'ollama'`) |
+| capabilities | `ProviderCapabilities` | Feature flags for this provider |
+| chatCompletion | `(options: ChatCompletionOptions) => Promise<ChatCompletionResult>` | Core chat method |
+| textCompletion? | `(prompt: string) => Promise<NodeJS.ReadableStream>` | Optional legacy text completion |
+| imageAnalysis? | `(imageUrl: string, prompt?: string) => Promise<string>` | Optional vision capability |
+
+**Changes**: No interface changes. Providers now export a `register()` function alongside the class.
+
+### ProviderRegistration (new interface)
+
+**Location**: `backend/src/providers/types.ts`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | `string` | Provider key used in MODEL_REGISTRY |
+| models | `ModelConfig[]` | Array of model configurations this provider supports |
+| capabilities | `ProviderCapabilities` | What this provider can do |
+| factory | `(modelId: string) => AIProvider` | Creates a provider instance for a specific model |
+
+**Validation rules**:
+- `name` must be unique across all registrations (duplicate → startup error)
+- `models` must have at least one entry
+- `factory` must return a valid AIProvider instance
+
+### ModelConfig (new interface)
+
+**Location**: `backend/src/providers/types.ts`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| key | `string` | User-facing model name (e.g., `'openai'`, `'lama'`) |
+| modelId | `string` | Provider-specific model identifier (e.g., `'gpt-4o-mini'`, `'llama3.2'`) |
+
+### SSEWriter (new class)
+
+**Location**: `backend/src/sse/sseWriter.ts`
+
+| Field/Method | Type | Description |
+|--------------|------|-------------|
+| constructor | `(res: Response)` | Wraps an Express Response, sets SSE headers |
+| sendMessageStart | `(data: MessageStartEvent) => void` | Emit `message_start` event |
+| sendDelta | `(data: DeltaEvent) => void` | Emit `content_block_delta` event |
+| sendToolUseStart | `(data: ToolUseStartEvent) => void` | Emit `content_block_start` event |
+| sendToolUseResult | `(data: ToolUseResultEvent) => void` | Emit `content_block_stop` event |
+| sendMessageStop | `(data: MessageStopEvent) => void` | Emit `message_stop` event |
+| sendError | `(data: ErrorEvent) => void` | Emit `error` event |
+| end | `() => void` | Close the SSE connection |
+
+**Validation rules**:
+- All event methods call `res.write(`data: ${JSON.stringify(payload)}\n\n`)`
+- Event type strings are hardcoded constants, not user-supplied
+- `end()` calls `res.end()` and prevents further writes
+
+### SSE Event Types (refactored)
+
+**Location**: `backend/src/sse/types.ts` (moved from `types/events.ts`)
+
+| Event Type | Payload Fields |
+|------------|---------------|
+| `message_start` | `message_id`, `assistant_msg_id`, `user_msg_id` |
+| `content_block_delta` | `index`, `delta: { type: 'text_delta', text }` |
+| `content_block_start` | `index`, `content_block: { type: 'tool_use', id, name, input }` |
+| `content_block_stop` | `index`, `tool_result: { tool_call_id, name, output, is_error }` |
+| `message_stop` | `stop_reason`, `tool_calls_count` |
+| `error` | `error: { type, message, retryable }` |
+
+**No changes to event shapes** — types are just moved to a dedicated location.
+
+### PromptLoader (new module)
+
+**Location**: `backend/src/prompts/index.ts`
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| getSystemPrompt | `(options: { supportsTools: boolean; date?: string; timezone?: string }) => string` | Returns appropriate system prompt based on model capabilities |
+
+**State transitions**: N/A (stateless function)
+
+### ContextService (refactored)
+
+**Location**: `backend/src/services/contextService.ts`
+
+Decomposed methods (all private except `buildContextWindow`):
+
+| Method | Description |
+|--------|-------------|
+| `buildContextWindow(threadId, maxTokens)` | Public entry: orchestrates pipeline |
+| `lookupCache(threadId)` | Returns cached messages or null |
+| `fetchMessages(threadId)` | DB query, returns chronological messages |
+| `applyTokenBudget(messages, maxTokens)` | Trims messages to fit token budget |
+| `enforceMinimumMessages(window, all)` | Ensures at least 4 messages |
+| `enforceRoleAlternation(messages)` | Removes consecutive same-role |
+| `validateLastRole(messages, threadId)` | Warns if last message isn't user role |
+
+No changes to the public API surface.
+
+## Relationships
+
+```
+ProviderRegistration  1 ──── * ModelConfig
+                      1 ──── 1 ProviderCapabilities
+                      1 ──── 1 AIProvider (via factory)
+
+SSEWriter             1 ──── 1 Express Response
+                      uses ── * SSE Event Types
+
+PromptLoader          reads ── default.ts, simple.ts
+                      called by ── chatService
+
+ContextService        calls ── Prisma (Message model)
+                      calls ── estimateTokens (private)
+                      calls ── extractText (private, uses shared utils)
+```
+
+## Unchanged Entities
+
+These entities are not modified by this refactor:
+
+- **Thread** (Prisma model) — no schema changes
+- **Message** (Prisma model) — no schema changes
+- **ToolCall** (Prisma model) — no schema changes
+- **RunnableTool** (interface) — tool registration stays manual per spec
+- **ToolRegistry** (singleton) — already clean, no changes
+- **AppError hierarchy** — already comprehensive, no changes

--- a/specs/002-backend-refactor/plan.md
+++ b/specs/002-backend-refactor/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Backend Architecture Refactor
+
+**Branch**: `002-backend-refactor` | **Date**: 2026-06-10 | **Spec**: `specs/002-backend-refactor/spec.md`
+**Input**: Feature specification from `specs/002-backend-refactor/spec.md`
+
+## Summary
+
+Refactor the backend to enforce clean architecture principles: slim controllers that only delegate, deduplicated provider logic via shared conversion utilities, consistent structured logging with correlation IDs, a self-registering provider pattern, an SSE writer abstraction, and externalized system prompts. All changes are purely structural — no API contract changes, no new features, no database schema changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (strict mode), Node.js LTS
+**Primary Dependencies**: Express 4.x, Prisma 5.22.0, pino, OpenAI SDK, @google/generative-ai, axios (Ollama), mathjs, zod
+**Storage**: PostgreSQL 16 via Prisma ORM. Models: Thread, Message, ToolCall. Content stored as JSONB.
+**Testing**: Jest + ts-jest + supertest. Tests in `backend/tests/`. Config in `backend/jest.config.ts`.
+**Target Platform**: Linux/macOS server (Docker Compose for production)
+**Project Type**: Web service (REST API + SSE streaming)
+**Performance Goals**: <200ms p95 non-streaming endpoints, <500ms first SSE delta (per constitution)
+**Constraints**: Preserve all existing API contracts (request/response shapes, SSE event types). No database schema changes.
+**Scale/Scope**: ~2,500 LOC backend TypeScript. 3 providers, 5 tools, 2 controllers, 6 services.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Gate
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | PASS | Refactor directly addresses: decompose large functions (contextService 110-line method, controller 156 lines), enforce single responsibility, eliminate dead code patterns. All new code will be TypeScript strict. |
+| II. Testing Standards | PASS | Existing tests must continue passing (FR-009). New shared utilities (message conversion, SSE writer) will have unit tests. Integration tests for API contracts unchanged. |
+| III. User Experience Consistency | PASS | No frontend changes. SSE event format preserved exactly (FR-009). Streaming behavior unchanged. |
+| IV. Performance Requirements | PASS | Refactor is structural only — no new queries, no new network calls, no bundle size impact. Provider abstraction adds negligible overhead (function call indirection). |
+
+**Gate Result**: PASS — no violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-backend-refactor/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── sse-events.md    # SSE event contract
+└── tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── src/
+│   ├── config/
+│   │   ├── logger.ts              # Pino logger setup (unchanged)
+│   │   └── database.ts            # Prisma client singleton (unchanged)
+│   ├── controllers/
+│   │   ├── messageController.ts   # REFACTOR: slim to ~30 lines, delegate to chatService
+│   │   └── threadController.ts    # REFACTOR: add logging, consistent error handling
+│   ├── middleware/
+│   │   ├── auth.ts                # Unchanged
+│   │   ├── errorHandler.ts        # REFACTOR: add logging
+│   │   └── requestLogger.ts       # REFACTOR: attach correlation ID to req
+│   ├── routes/
+│   │   ├── messageRoutes.ts       # Unchanged
+│   │   └── threadRoutes.ts        # Unchanged
+│   ├── services/
+│   │   ├── chatService.ts         # REFACTOR: extract SSE writer usage, prompt loading
+│   │   ├── messageService.ts      # Unchanged (already clean)
+│   │   ├── threadService.ts       # REFACTOR: receive incrementThreadTokens from messageService
+│   │   ├── contextService.ts      # REFACTOR: decompose buildContextWindow into helpers
+│   │   ├── toolExecutor.ts        # REFACTOR: use correlation ID in logging
+│   │   └── toolRegistry.ts        # Unchanged (already clean)
+│   ├── providers/
+│   │   ├── index.ts               # REFACTOR: auto-registration via directory scan
+│   │   ├── types.ts               # REFACTOR: add register() export convention
+│   │   ├── utils.ts               # NEW: shared message conversion utilities
+│   │   ├── openai.ts              # REFACTOR: use shared utils, remove duplicate logic
+│   │   ├── google.ts              # REFACTOR: use shared utils, remove duplicate logic
+│   │   └── ollama.ts              # REFACTOR: use shared utils, remove duplicate logic
+│   ├── tools/                     # Unchanged (already follows clean patterns)
+│   ├── prompts/                   # NEW: externalized system prompt files
+│   │   ├── index.ts               # Prompt loader
+│   │   ├── default.ts             # Default tool-capable system prompt
+│   │   └── simple.ts              # Non-tool-capable model prompt
+│   ├── sse/                       # NEW: SSE writer abstraction
+│   │   ├── sseWriter.ts           # SSE event formatting and writing
+│   │   └── types.ts               # SSE event type definitions (moved from types/events.ts)
+│   ├── types/
+│   │   ├── messages.ts            # Unchanged
+│   │   ├── content.ts             # Unchanged
+│   │   ├── events.ts              # REFACTOR: re-export from sse/types.ts
+│   │   └── index.ts               # Unchanged
+│   ├── errors/
+│   │   └── index.ts               # Unchanged (already comprehensive)
+│   └── server.ts                  # REFACTOR: provider auto-registration at startup
+├── prisma/
+│   └── schema.prisma              # Unchanged (no schema changes)
+└── tests/
+    ├── providers/
+    │   └── utils.test.ts           # NEW: tests for shared conversion utilities
+    ├── services/
+    │   └── contextService.test.ts  # UPDATE: test decomposed helpers
+    └── sse/
+        └── sseWriter.test.ts       # NEW: tests for SSE writer
+```
+
+**Structure Decision**: Existing web application structure retained. Three new directories added under `backend/src/`: `prompts/` for externalized system prompts, `sse/` for SSE writer abstraction, `providers/utils.ts` for shared conversion utilities. No structural changes to frontend.
+
+## Post-Design Constitution Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | PASS | All new code is TypeScript strict. New modules (`providers/utils.ts`, `sse/sseWriter.ts`, `prompts/`) each have single responsibility. No function exceeds 50 lines in the design. Shared utils eliminate duplication. |
+| II. Testing Standards | PASS | New shared utilities get unit tests (`providers/utils.test.ts`). SSE writer gets unit tests (`sse/sseWriter.test.ts`). Existing integration tests must pass unmodified (FR-009). |
+| III. User Experience Consistency | PASS | No frontend changes. SSE event format preserved exactly per `contracts/sse-events.md`. No user-visible behavior changes. |
+| IV. Performance Requirements | PASS | No new DB queries. Provider auto-registration adds ~10ms at startup (one-time directory scan). Shared utility functions are zero-overhead (same operations, different location). |
+
+**Post-Design Gate Result**: PASS — no violations.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/002-backend-refactor/quickstart.md
+++ b/specs/002-backend-refactor/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart: Backend Architecture Refactor
+
+**Feature**: 002-backend-refactor | **Date**: 2026-06-10
+
+## Prerequisites
+
+- Node.js LTS, Docker Compose running (PostgreSQL + SearXNG)
+- `backend/.env` configured (see `backend/.env.example`)
+- Database migrated: `cd backend && npx prisma migrate dev`
+
+## Running the Backend
+
+```bash
+cd backend
+npm run dev    # nodemon with auto-restart
+```
+
+Backend runs on `http://localhost:5001`. Frontend on `http://localhost:3000`.
+
+## Running Tests
+
+```bash
+cd backend
+npm test                    # all tests
+npx jest --watch            # watch mode
+npx jest tests/providers/   # provider tests only
+npx jest tests/sse/         # SSE writer tests only
+```
+
+## Verification Checklist
+
+After the refactor, verify these behaviors are preserved:
+
+### 1. API Contracts (no changes expected)
+
+```bash
+# Create a thread
+curl -X POST http://localhost:5001/api/v1/threads \
+  -H "Content-Type: application/json" \
+  -d '{"model": "openai", "title": "Test"}'
+
+# Send a message (SSE stream)
+curl -N -X POST http://localhost:5001/api/v1/threads/{id}/messages \
+  -H "Content-Type: application/json" \
+  -d '{"content": [{"type": "text", "text": "Hello"}]}'
+
+# List threads
+curl http://localhost:5001/api/v1/threads
+```
+
+### 2. SSE Event Sequence
+
+Verify the stream produces events in order: `message_start` → `content_block_delta`* → `message_stop`. See `contracts/sse-events.md` for the full event schema.
+
+### 3. Tool Calling
+
+Send a message that triggers a tool call (e.g., "what is 2+2?") and verify:
+- `content_block_start` event with tool name and arguments
+- `content_block_stop` event with tool result
+- Final `message_stop` with correct `tool_calls_count`
+
+### 4. Provider Verification
+
+Test each provider to confirm the refactored shared utilities work:
+- OpenAI: `{"model": "openai"}` — streaming + tool calls
+- Google: `{"model": "google"}` — non-streaming + tool calls
+- Ollama: `{"model": "lama"}` — streaming + tool calls (requires local Ollama)
+
+### 5. Logging Verification
+
+After sending a message, check console output for:
+- Thread controller operations now produce `info`-level structured logs
+- Correlation ID (`requestId`) appears in all log lines for a single request
+- Tool execution logs include: name, duration, input size, output size, success/failure
+
+## Key Files Changed
+
+| Area | Files | What Changed |
+|------|-------|-------------|
+| Controllers | `messageController.ts`, `threadController.ts` | Slimmed handlers, SSEWriter usage, logging |
+| Providers | `openai.ts`, `google.ts`, `ollama.ts`, `index.ts` | Use shared utils, auto-registration |
+| New: Shared utils | `providers/utils.ts` | `extractTextContent()`, `mapToolResult()`, `buildToolCallContentBlock()` |
+| New: SSE writer | `sse/sseWriter.ts`, `sse/types.ts` | SSE event abstraction |
+| New: Prompts | `prompts/index.ts`, `prompts/default.ts`, `prompts/simple.ts` | Externalized system prompts |
+| Services | `contextService.ts`, `chatService.ts`, `threadService.ts` | Decomposed methods, prompt loading, token relocation |
+| Middleware | `requestLogger.ts`, `errorHandler.ts` | Correlation ID propagation, error logging |

--- a/specs/002-backend-refactor/research.md
+++ b/specs/002-backend-refactor/research.md
@@ -1,0 +1,127 @@
+# Research: Backend Architecture Refactor
+
+**Feature**: 002-backend-refactor | **Date**: 2026-06-10
+
+## R-001: Shared Message Conversion Utilities
+
+**Decision**: Create `backend/src/providers/utils.ts` with three shared functions: `extractTextContent()`, `mapToolResult()`, and `buildToolCallContentBlock()`.
+
+**Rationale**: The text-block filtering pattern (`.filter(b => b.type === 'text').map(b => b.text).join(' ')`) is duplicated 6 times across openai.ts:45-48, google.ts:59-62, ollama.ts:62-65, messageController.ts:111-114, and contextService.ts (twice at lines 70-72 and 144-147). Tool result detection (`msg.content.find(b => b.type === 'tool_result')`) is duplicated in all 3 providers. Tool call to content block mapping (pushing `{ type: 'tool_use', id, name, input }`) is identical across all 3 providers.
+
+**Alternatives considered**:
+- A `MessageConverter` class with provider-specific subclasses — rejected because the conversions are stateless pure functions; a class adds unnecessary indirection.
+- Putting utilities in `types/` — rejected because these are runtime functions, not type definitions.
+
+## R-002: Provider Auto-Registration Pattern
+
+**Decision**: Each provider file exports a `register()` function that returns `{ name, models[], capabilities, factory() }`. At startup, `providers/index.ts` dynamically imports all `.ts` files in the `providers/` directory (excluding `index.ts`, `types.ts`, `utils.ts`) and calls each `register()` function to populate the MODEL_REGISTRY and provider factory map.
+
+**Rationale**: The current pattern requires editing `providers/index.ts` to add entries to both the `MODEL_REGISTRY` object and the factory switch. This violates open/closed principle (FR-004, SC-004). Auto-registration via directory scanning means a new provider is just a new file.
+
+**Alternatives considered**:
+- Decorator-based registration (`@Provider('openai')`) — rejected because TypeScript decorators are experimental and add build complexity.
+- Plugin framework (dynamic `require()` from a config file) — rejected as over-engineered for 3-5 providers; directory scanning is simpler and sufficient.
+- Import map in a config file — rejected because it still requires editing a file when adding a provider.
+
+## R-003: SSE Writer Abstraction
+
+**Decision**: Create `backend/src/sse/sseWriter.ts` exporting an `SSEWriter` class that wraps an Express `Response` object and provides typed methods: `sendMessageStart()`, `sendDelta()`, `sendToolUseStart()`, `sendToolUseResult()`, `sendMessageStop()`, `sendError()`. Each method internally calls `res.write()` with proper `data:` formatting and `JSON.stringify`.
+
+**Rationale**: The message controller currently has 6 inline `res.write(\`data: ${JSON.stringify(...)}\n\n\`)` calls (lines 67-153) mixing transport formatting with business logic. The SSE writer encapsulates the wire format so the controller works with semantic events (FR-005).
+
+**Alternatives considered**:
+- Plain helper functions (not a class) — rejected because the writer needs to hold a reference to `res` and track connection state (client disconnect detection).
+- EventEmitter pattern — rejected because the controller is the producer, not the consumer; an emitter adds indirection without benefit.
+- Middleware-based SSE setup — rejected because SSE is only used by one endpoint; middleware would be unused elsewhere.
+
+## R-004: System Prompt Externalization
+
+**Decision**: Create `backend/src/prompts/` directory with individual prompt files (`default.ts`, `simple.ts`) exporting string-returning functions. A `prompts/index.ts` loader selects the appropriate prompt based on model capabilities (supports tools vs. does not). Prompts are TypeScript template literals, not external text files, to keep them type-safe and allow dynamic values (current date, timezone).
+
+**Rationale**: `chatService.ts` has a 45-line `SYSTEM_PROMPT` constant (lines 11-45) and a 3-line `SIMPLE_PROMPT` (lines 56-58) embedded directly in the service. Prompt text changes frequently during development and should not require editing service logic (FR-006). The current hardcoded timezone (`'Asia/Dhaka (UTC+6)'`) and date (`new Date().toISOString()`) should be parameterizable.
+
+**Alternatives considered**:
+- External `.txt` or `.md` files loaded at runtime — rejected because prompts contain dynamic interpolation (date, timezone) and TypeScript gives compile-time safety.
+- Database-stored prompts — rejected per spec assumption: "System prompts will be co-located with the backend code."
+- YAML/JSON config files — rejected because template literal syntax is more readable for multi-line prompts with interpolation.
+
+## R-005: Controller Slimming Strategy
+
+**Decision**: Decompose `handleSendMessage` (156 lines) into:
+1. Request validation (extract and validate body fields)
+2. Message creation (delegate to messageService)
+3. SSE setup (instantiate SSEWriter, set headers)
+4. Processing delegation (call chatService.processMessage with SSEWriter callbacks)
+5. Completion handling (update message status, auto-title)
+
+The controller method itself becomes a ~25-line orchestrator. Each step is either an inline expression or a service call. No new "helper" functions in the controller file — logic moves to services.
+
+**Rationale**: FR-001 requires controllers to contain only validation, delegation, and response formatting. SC-001 caps handlers at 30 lines. The current handler mixes SSE setup, message persistence, auto-title generation, token counting, cache invalidation, and error formatting.
+
+**Alternatives considered**:
+- Express middleware chain (one middleware per concern) — rejected because SSE streaming makes middleware composition awkward (response is held open).
+- Command pattern (create a SendMessage command object) — rejected as over-engineering for a single endpoint.
+
+## R-006: Context Service Decomposition
+
+**Decision**: Break `buildContextWindow` (110+ lines) into focused private methods:
+- `lookupCache(threadId)` — cache hit/miss (lines 17-22)
+- `fetchMessages(threadId)` — DB query + chronological ordering (lines 24-42)
+- `applyTokenBudget(messages, maxTokens)` — walk from newest, respect budget (lines 47-58)
+- `enforceMinimumMessages(window, allMessages)` — safety floor of 4 messages (lines 60-62)
+- `enforceRoleAlternation(messages)` — remove consecutive same-role (lines 75-95)
+- `validateLastRole(messages)` — warn if last message not from user (lines 97-103)
+
+The public `buildContextWindow` becomes a pipeline calling these in sequence.
+
+**Rationale**: FR-008 requires decomposition. SC-006 caps functions at 50 lines. The current method is 110+ lines with 7 distinct phases. Each phase is independently testable.
+
+**Alternatives considered**:
+- Pipeline pattern (array of transform functions) — rejected because the phases have different signatures and side effects (caching, logging); explicit method calls are clearer.
+- Separate class per phase — rejected as over-abstraction for private methods within a single service.
+
+## R-007: Correlation ID Propagation
+
+**Decision**: The existing `requestLogger.ts` middleware already generates a request ID (from `x-request-id` header or UUID). Propagate this ID by:
+1. Attaching it to `req` (already done as `req.id`)
+2. Passing it through service calls as part of a context object or logger child
+3. Using `logger.child({ requestId: req.id })` at the controller level and passing the child logger through the service chain
+
+**Rationale**: FR-003 requires a correlation ID that traces through controller → service → provider → tool. The existing request ID generation is solid; it just isn't propagated past the middleware layer.
+
+**Alternatives considered**:
+- AsyncLocalStorage (Node.js CLS) — rejected because it adds hidden coupling and is harder to test. Explicit parameter passing is more traceable.
+- Middleware that sets a global context — rejected because globals don't work with concurrent requests.
+
+## R-008: Logging Gaps
+
+**Decision**: Add structured logging to:
+1. `threadController.ts` — currently has zero logging. Add operation + duration logging to all 5 handlers.
+2. `errorHandler.ts` middleware — add `log.error({ err, statusCode })` before sending response.
+3. All controller handlers — add duration tracking via `Date.now()` at start and log at completion.
+
+**Rationale**: FR-003 requires 100% controller coverage with operation name, entity IDs, correlation ID, and duration. SC-003 measures this. Thread controller has zero logging; error middleware silently swallows errors.
+
+**Alternatives considered**:
+- AOP-style logging decorators — rejected because Express handlers aren't class methods; decorators would require a wrapper pattern.
+- Middleware that auto-logs all handlers — rejected because handler-specific context (entity IDs, operation names) can't be inferred generically.
+
+## R-009: incrementThreadTokens Relocation
+
+**Decision**: Move `incrementThreadTokens` from `messageService.ts` to `threadService.ts`. Update the single call site in `messageController.ts` (or `chatService.ts` after controller slimming) to import from `threadService`.
+
+**Rationale**: FR-007 explicitly requires this. The function operates on the Thread entity, not Message. It's a single function relocation with one import change.
+
+**Alternatives considered**: None — this is a straightforward relocation dictated by the spec.
+
+## R-010: Error Handling Consistency
+
+**Decision**: Audit all controller handlers and ensure they:
+1. Use `throw` with AppError subclasses exclusively (no manual `res.status().json()` for error cases)
+2. Let the error middleware catch and format all errors
+3. Remove any mixed patterns
+
+**Rationale**: FR-010 requires consistent error handling using the existing AppError hierarchy. The current thread controller uses string message matching in some places alongside proper AppError throwing.
+
+**Alternatives considered**:
+- Zod-based request validation middleware — good idea but out of scope for this refactor (no new features). Can be a follow-up.

--- a/specs/002-backend-refactor/spec.md
+++ b/specs/002-backend-refactor/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: Backend Architecture Refactor
+
+**Feature Branch**: `002-backend-refactor`
+**Created**: 2026-06-10
+**Status**: Draft
+**Input**: User description: "check the backend code and refactor based on following principles: follow standard architecture, clear and readable, remove redundant logic and code, add standard logging, make architecture extensible"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Controller Simplification (Priority: P1)
+
+A developer modifying the message-sending flow currently has to read through a 156-line controller method that mixes SSE formatting, database operations, cache invalidation, auto-title generation, and token counting. The controller should only coordinate — all business logic should live in service-layer methods.
+
+**Why this priority**: The message controller is the most-changed file and the highest-risk area for regressions. Every feature touching chat flows must navigate this bloated handler.
+
+**Independent Test**: A developer can read `handleSendMessage` and understand the flow in under 2 minutes without cross-referencing service internals.
+
+**Acceptance Scenarios**:
+
+1. **Given** a request to send a message, **When** examining the controller, **Then** it contains no direct database calls, no cache invalidation logic, and no auto-title generation — only delegation to services.
+2. **Given** the message controller, **When** counting responsibilities, **Then** each handler has exactly one responsibility: validate input, delegate to a service, and format the response.
+3. **Given** the existing thread controller, **When** reviewing its handlers, **Then** error-handling patterns are consistent (no mixed `throw` vs. manual `res.status()` patterns).
+
+---
+
+### User Story 2 - Eliminate Duplicate Provider Logic (Priority: P1)
+
+When adding a new AI provider, a developer must copy-paste the same message-format conversion logic (content block extraction, tool-result mapping) from an existing provider. Three providers currently duplicate the same text-extraction and tool-result-to-role conversion patterns.
+
+**Why this priority**: Redundant logic makes every provider change a 3x effort and a source of inconsistency bugs.
+
+**Independent Test**: Add a mock provider with zero message-conversion code — all format translation is handled by shared utilities.
+
+**Acceptance Scenarios**:
+
+1. **Given** three provider implementations, **When** searching for text-extraction logic (filtering content blocks by type "text"), **Then** it exists in exactly one shared location, not in each provider.
+2. **Given** a message with tool_result content blocks, **When** converting for any provider, **Then** the conversion uses a single shared function, not provider-specific inline code.
+3. **Given** the OpenAI, Ollama, and Google providers, **When** comparing their `chatCompletion` methods, **Then** each contains only provider-specific API calls — no duplicated message mapping.
+
+---
+
+### User Story 3 - Add Comprehensive Logging (Priority: P2)
+
+An operator investigating a slow response has no visibility into thread controller operations, incomplete request tracing in the message flow, and no operational-level timing data for tool execution. Logging coverage is inconsistent across the codebase.
+
+**Why this priority**: Without consistent logging, debugging production issues requires code reading instead of log analysis.
+
+**Independent Test**: Process a message with tool calls and verify that every significant operation (thread lookup, message creation, provider call, tool execution, response completion) produces a structured log entry with timing data.
+
+**Acceptance Scenarios**:
+
+1. **Given** any controller handler, **When** a request is processed, **Then** a structured log entry is emitted at `info` level with operation name, duration, and relevant IDs.
+2. **Given** the thread controller, **When** any thread operation occurs, **Then** it produces log entries (currently has zero logging).
+3. **Given** a tool execution, **When** it completes, **Then** the log includes tool name, duration, input size, output size, and success/failure status at `info` level.
+
+---
+
+### User Story 4 - Provider Registration Pattern (Priority: P2)
+
+Adding a new AI provider requires editing the factory's switch statement and the MODEL_REGISTRY constant in the same file. A developer should be able to add a provider by creating a single file with a self-contained registration, without modifying existing code.
+
+**Why this priority**: The current factory pattern violates open/closed principle and makes provider addition error-prone.
+
+**Independent Test**: Add a new provider by creating one file — no modifications to any existing file are required for it to be available.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new AI provider implementation, **When** a developer creates a provider file following the established pattern, **Then** the provider is available without modifying the factory or registry file.
+2. **Given** the provider registry, **When** listing available providers at runtime, **Then** all registered providers appear with their capabilities and model configurations.
+3. **Given** a removed provider file, **When** the system starts, **Then** it gracefully operates without the removed provider.
+
+---
+
+### User Story 5 - SSE Response Abstraction (Priority: P3)
+
+SSE event formatting is hardcoded inline in the message controller with `res.write` calls and `JSON.stringify`. Adding a new SSE event type or changing the event format requires editing the controller. The SSE protocol should be encapsulated so controllers write semantic events, not raw strings.
+
+**Why this priority**: SSE formatting scattered in the controller couples transport protocol to business logic and creates inconsistency risk.
+
+**Independent Test**: Change the SSE event format in one place and verify all events update consistently, without touching the controller.
+
+**Acceptance Scenarios**:
+
+1. **Given** the message controller, **When** examining SSE-related code, **Then** it uses a writer abstraction (not raw `res.write` with `JSON.stringify`).
+2. **Given** any SSE event type, **When** emitting it, **Then** the event follows a consistent format defined in one location.
+
+---
+
+### User Story 6 - System Prompt Separation (Priority: P3)
+
+System prompts are embedded as multi-line string constants inside the chat service. Modifying prompts requires editing business logic code. Prompts should be managed separately so they can be updated, versioned, or customized per model without changing the service.
+
+**Why this priority**: Prompt content changes frequently during development and should not require service-layer code changes.
+
+**Independent Test**: Update a system prompt's wording and verify the change takes effect without modifying any service file.
+
+**Acceptance Scenarios**:
+
+1. **Given** the chat service, **When** examining its source, **Then** it contains no embedded prompt text — prompts are loaded from a separate source.
+2. **Given** a model that does not support tools, **When** a message is processed, **Then** the service selects the appropriate prompt variant without hardcoded model-name checks.
+
+---
+
+### Edge Cases
+
+- What happens when a provider is registered with a name that already exists? System MUST reject the duplicate with a clear error.
+- What happens when the shared message-conversion utility encounters an unknown content block type? It MUST pass through without error (forward compatibility).
+- What happens when a controller receives a request after the SSE connection is closed by the client? The system MUST handle write-after-close gracefully without crashing.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Controller handlers MUST contain only request validation, service delegation, and response formatting — no direct database calls, no business logic.
+- **FR-002**: Message format conversion (content blocks to/from provider-specific formats) MUST be implemented once in shared utilities, reused by all providers.
+- **FR-003**: Every controller handler MUST emit structured log entries with operation name, relevant entity IDs, request correlation ID, and duration at `info` level. The correlation ID MUST propagate through all layers (controller → service → provider → tool) so a single request can be traced end-to-end.
+- **FR-004**: New AI providers MUST be addable by creating a self-contained file without modifying existing source files.
+- **FR-005**: SSE event emission MUST be encapsulated in a reusable abstraction that the controller calls with semantic event data.
+- **FR-006**: System prompts MUST be managed outside of service logic, loadable by model or capability profile.
+- **FR-007**: The `incrementThreadTokens` function MUST be relocated from messageService to threadService (it operates on Thread, not Message).
+- **FR-008**: The context service's `buildContextWindow` method MUST be decomposed into focused helper methods (cache lookup, DB fetch, token budgeting, role alternation).
+- **FR-009**: All refactored code MUST maintain existing API contracts — no changes to request/response shapes or SSE event types.
+- **FR-010**: Error handling in controllers MUST use the existing AppError hierarchy consistently — no mixed patterns of `throw` vs manual `res.status()`.
+
+### Key Entities
+
+- **AIProvider**: Interface for AI model integrations. Currently three implementations with duplicated conversion logic.
+- **RunnableTool**: Interface for tool implementations with Zod validation. Registration is intentionally manual — the frontend controls tool availability per request.
+- **ContextService**: In-memory cached context builder. Single 162-line method needs decomposition.
+- **StreamEvent**: Typed SSE events currently serialized inline in the controller.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: No controller handler exceeds 30 lines of code (currently 120+ for handleSendMessage).
+- **SC-002**: Message format conversion code exists in exactly one shared location — zero duplication across providers.
+- **SC-003**: 100% of controller operations produce structured log entries with timing data.
+- **SC-004**: Adding a new provider requires creating exactly one file, modifying zero existing files.
+- **SC-005**: All existing API integration tests pass without modification after refactor.
+- **SC-006**: No function in the codebase exceeds 50 lines (per constitution Principle I).
+- **SC-007**: Every service-layer file has a single clear responsibility — no file combines unrelated concerns.
+
+## Clarifications
+
+### Session 2026-06-10
+
+- Q: Should tool registration also follow the auto-registration pattern like providers? → A: No — tool registration stays manual. The frontend controls which tools are available per request, so explicit registration is intentional.
+- Q: Should logging include a request correlation ID across all layers? → A: Yes — add a correlation ID that traces a single request from controller through service, provider, and tool execution.
+- Q: Should the refactor be delivered as one PR or incrementally? → A: Single PR with all 6 user stories.
+
+## Assumptions
+
+- The refactor is purely structural — no new features, no API contract changes, no database schema changes. All changes land in a single PR.
+- Existing test coverage is sufficient to catch regressions; additional tests will be added for new shared utilities.
+- The current Anthropic-style type system (ContentBlock, ToolUseBlock, etc.) remains the canonical internal format.
+- Provider auto-registration can use a simple directory-scanning pattern at startup rather than requiring a plugin framework.
+- System prompts will be co-located with the backend code (not externalized to a database or config service).

--- a/specs/002-backend-refactor/tasks.md
+++ b/specs/002-backend-refactor/tasks.md
@@ -1,0 +1,291 @@
+# Tasks: Backend Architecture Refactor
+
+**Input**: Design documents from `/specs/002-backend-refactor/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/sse-events.md, quickstart.md
+
+**Tests**: New shared utilities (provider utils, SSEWriter) receive unit tests as specified in plan.md. Existing tests must pass unmodified (FR-009, SC-005).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create new directory structure for modules introduced by this refactor
+
+- [ ] T001 Create new directories: backend/src/prompts/, backend/src/sse/, backend/tests/sse/
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create all new modules, interfaces, and shared utilities that user stories depend on. No existing behavior is changed in this phase — only new files are created and minimal re-exports added.
+
+**Serves**: US5 (SSEWriter, SSE types), US6 (PromptLoader, prompt files), US2 (shared conversion utils), US4 (ProviderRegistration types), US3 (correlation ID propagation), US1 (incrementThreadTokens relocation)
+
+- [ ] T002 [P] Define ProviderRegistration, ModelConfig, and ProviderCapabilities interfaces with register() export convention in backend/src/providers/types.ts
+- [ ] T003 [P] Create SSE event type definitions (MessageStartEvent, DeltaEvent, ToolUseStartEvent, ToolUseResultEvent, MessageStopEvent, ErrorEvent) in backend/src/sse/types.ts
+- [ ] T004 [P] Create shared message conversion utilities (extractTextContent, mapToolResult, buildToolCallContentBlock) in backend/src/providers/utils.ts
+- [ ] T005 [P] Create default tool-capable system prompt as a parameterized template literal (date, timezone) in backend/src/prompts/default.ts
+- [ ] T006 [P] Create simple non-tool system prompt as a parameterized template literal in backend/src/prompts/simple.ts
+- [ ] T007 Create prompt loader getSystemPrompt({ supportsTools, date?, timezone? }) in backend/src/prompts/index.ts
+- [ ] T008 Create SSEWriter class with typed event methods (sendMessageStart, sendDelta, sendToolUseStart, sendToolUseResult, sendMessageStop, sendError, end) and client disconnect protection in backend/src/sse/sseWriter.ts
+- [ ] T009 Re-export SSE types from backend/src/types/events.ts pointing to backend/src/sse/types.ts for backward compatibility
+- [ ] T010 [P] Update requestLogger middleware to attach correlation ID (req.id) for downstream propagation in backend/src/middleware/requestLogger.ts
+- [ ] T011 [P] Move incrementThreadTokens function from messageService to threadService and update import in call site in backend/src/services/threadService.ts
+- [ ] T012 Write unit tests for extractTextContent, mapToolResult, and buildToolCallContentBlock including unknown content block passthrough in backend/tests/providers/utils.test.ts
+- [ ] T013 Write unit tests for SSEWriter including event formatting, connection state tracking, and write-after-close protection in backend/tests/sse/sseWriter.test.ts
+
+**Checkpoint**: All new modules exist and pass their tests. No existing behavior changed yet.
+
+---
+
+## Phase 3: User Story 1 — Controller Simplification (Priority: P1) :dart: MVP
+
+**Goal**: Slim controllers to ~25-line handlers that only validate, delegate, and format responses. All business logic moves to services.
+
+**Independent Test**: A developer can read `handleSendMessage` and understand the flow in under 2 minutes without cross-referencing service internals.
+
+### Implementation for User Story 1
+
+- [ ] T014 [US1] Decompose contextService.buildContextWindow into focused helper methods (lookupCache, fetchMessages, applyTokenBudget, enforceMinimumMessages, enforceRoleAlternation, validateLastRole) in backend/src/services/contextService.ts
+- [ ] T015 [US1] Refactor chatService to use PromptLoader for system prompts and accept SSEWriter callbacks for event emission, removing embedded prompt text and inline res.write calls in backend/src/services/chatService.ts
+- [ ] T016 [US1] Slim messageController.handleSendMessage to ~25 lines: validate input, create SSEWriter, delegate to chatService, handle completion in backend/src/controllers/messageController.ts
+- [ ] T017 [US1] Standardize threadController error handling: replace all manual res.status().json() patterns with throw AppError exclusively in backend/src/controllers/threadController.ts
+- [ ] T018 [US1] Update contextService tests to cover decomposed helper methods (lookupCache, fetchMessages, applyTokenBudget, enforceRoleAlternation) in backend/tests/services/contextService.test.ts
+
+**Checkpoint**: Controllers are slim orchestrators. `handleSendMessage` is ~25 lines. All existing tests pass unmodified.
+
+---
+
+## Phase 4: User Story 2 — Eliminate Duplicate Provider Logic (Priority: P1)
+
+**Goal**: All message format conversion (text extraction, tool result mapping) lives in one shared location. Providers contain only provider-specific API calls.
+
+**Independent Test**: Add a mock provider with zero message-conversion code — all format translation handled by shared utilities from backend/src/providers/utils.ts.
+
+### Implementation for User Story 2
+
+- [ ] T019 [P] [US2] Refactor OpenAI provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/openai.ts
+- [ ] T020 [P] [US2] Refactor Google provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/google.ts
+- [ ] T021 [P] [US2] Refactor Ollama provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/ollama.ts
+
+**Checkpoint**: Text extraction logic (`.filter(b => b.type === 'text')...`) exists in exactly one location. Each provider's `chatCompletion` contains only provider-specific API calls.
+
+---
+
+## Phase 5: User Story 3 — Add Comprehensive Logging (Priority: P2)
+
+**Goal**: Every significant operation produces a structured log entry with operation name, entity IDs, correlation ID, and duration at info level.
+
+**Independent Test**: Process a message with tool calls and verify that every operation (thread lookup, message creation, provider call, tool execution, response completion) produces a structured log entry with timing data.
+
+### Implementation for User Story 3
+
+- [ ] T022 [P] [US3] Add structured logging with operation name, entity IDs, duration, and child logger (requestId) to all five threadController handlers in backend/src/controllers/threadController.ts
+- [ ] T023 [P] [US3] Add error logging with err object, statusCode, and correlation ID to errorHandler middleware in backend/src/middleware/errorHandler.ts
+- [ ] T024 [P] [US3] Add operation timing (Date.now delta) and correlation ID via logger.child({ requestId }) to messageController handlers in backend/src/controllers/messageController.ts
+- [ ] T025 [US3] Enhance tool execution logging with tool name, duration, input size, output size, success/failure status, and correlation ID in backend/src/services/toolExecutor.ts
+
+**Checkpoint**: Thread controller has structured logging (was zero). All controller operations include duration. Correlation ID traces from controller through tool execution.
+
+---
+
+## Phase 6: User Story 4 — Provider Registration Pattern (Priority: P2)
+
+**Goal**: A new AI provider is added by creating a single file — no modifications to any existing file required.
+
+**Independent Test**: Add a new provider by creating one file. Verify it appears in the registry without modifying providers/index.ts.
+
+### Implementation for User Story 4
+
+- [ ] T026 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to OpenAI provider in backend/src/providers/openai.ts
+- [ ] T027 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to Google provider in backend/src/providers/google.ts
+- [ ] T028 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to Ollama provider in backend/src/providers/ollama.ts
+- [ ] T029 [US4] Implement auto-registration: scan providers/ directory for .ts files (excluding index.ts, types.ts, utils.ts), call each register(), populate MODEL_REGISTRY and factory map, reject duplicate names in backend/src/providers/index.ts
+- [ ] T030 [US4] Update server.ts to call provider auto-registration at startup and log registered providers in backend/src/server.ts
+
+**Checkpoint**: Removing a provider file and restarting → provider absent, no errors. Adding a file with register() → provider available. Duplicate name → startup error.
+
+---
+
+## Phase 7: User Story 5 — SSE Response Abstraction (Priority: P3)
+
+**Goal**: SSE event formatting is encapsulated in a reusable abstraction. Controllers write semantic events, not raw strings.
+
+**Independent Test**: Change the SSE event format in one place (backend/src/sse/sseWriter.ts) and verify all events update consistently, without touching the controller.
+
+**Status**: Fully implemented by earlier phases:
+
+| Acceptance Criterion | Implemented By |
+|---|---|
+| Controller uses SSEWriter, not raw res.write | T008 (create SSEWriter), T016 (controller integration) |
+| All events follow consistent format from one location | T003 (SSE types), T008 (SSEWriter methods) |
+| Write-after-close handled gracefully | T008 (disconnect protection), T013 (tests) |
+
+No additional tasks required.
+
+---
+
+## Phase 8: User Story 6 — System Prompt Separation (Priority: P3)
+
+**Goal**: System prompts are managed outside service logic, loadable by model capability profile. No embedded prompt text in services.
+
+**Independent Test**: Update a system prompt's wording in backend/src/prompts/default.ts and verify the change takes effect without modifying any service file.
+
+**Status**: Fully implemented by earlier phases:
+
+| Acceptance Criterion | Implemented By |
+|---|---|
+| ChatService contains no embedded prompt text | T005, T006 (prompt files), T007 (loader), T015 (chatService refactor) |
+| Capability-based prompt selection (no hardcoded model checks) | T007 (supportsTools flag), T015 (chatService uses getSystemPrompt) |
+
+No additional tasks required.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification that the refactor maintains all contracts and meets success criteria
+
+- [ ] T031 [P] Run full backend test suite to verify all existing tests pass without modification (SC-005)
+- [ ] T032 [P] Audit all functions to verify none exceeds 50 lines (SC-006) and no controller handler exceeds 30 lines (SC-001)
+- [ ] T033 Run quickstart.md verification checklist: API contracts, SSE event sequence, tool calling, provider verification, logging verification
+- [ ] T034 Verify message format conversion code exists in exactly one shared location with zero duplication across providers (SC-002)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Setup — **BLOCKS all user stories**
+- **US1 (Phase 3)**: Depends on Foundational (T007 for PromptLoader, T008 for SSEWriter, T011 for incrementThreadTokens)
+- **US2 (Phase 4)**: Depends on Foundational (T004 for shared utils). Independent of US1.
+- **US3 (Phase 5)**: Depends on Foundational (T010 for correlation ID). Best done after US1 (T016, T017 — controllers are cleaner to add logging to)
+- **US4 (Phase 6)**: Depends on Foundational (T002 for ProviderRegistration types). Best done after US2 (T019-T021 — providers already refactored)
+- **US5 (Phase 7)**: No tasks — completed by Foundational + US1
+- **US6 (Phase 8)**: No tasks — completed by Foundational + US1
+- **Polish (Phase 9)**: Depends on all user story phases being complete
+
+### Intra-Phase Dependencies (Foundational)
+
+```
+Group 1 [P]: T002, T003, T004, T005, T006, T010, T011  (all independent, parallel)
+Group 2:     T007 (after T005+T006), T008 (after T003), T009 (after T003)
+Group 3:     T012 (after T004), T013 (after T008)
+```
+
+### Intra-Phase Dependencies (US1)
+
+```
+T014 (contextService decompose) — independent, can start first
+T015 (chatService refactor) — independent of T014
+T016 (messageController slim) — after T015 (chatService API must be finalized)
+T017 (threadController errors) — independent of T014-T016
+T018 (contextService tests) — after T014
+```
+
+### User Story Independence
+
+- **US1 and US2** are both P1 and can be implemented in **parallel** after Foundational completes (they touch different files)
+- **US3 and US4** are both P2 and can be implemented in **parallel** (US3 touches controllers/middleware, US4 touches providers/index/server)
+- **US5 and US6** have no additional tasks — satisfied by Foundational + US1
+
+### Edge Cases (from spec)
+
+| Edge Case | Handled By |
+|---|---|
+| Duplicate provider name at registration | T029 — reject with startup error |
+| Unknown content block type in conversion | T004 — passthrough without error (forward compatibility) |
+| Write after SSE connection closed by client | T008 — connection state tracking, graceful no-op |
+
+---
+
+## Parallel Opportunities
+
+### Foundational Phase
+
+```
+Parallel group 1: T002, T003, T004, T005, T006, T010, T011
+Then:             T007 (needs T005+T006), T008 (needs T003), T009 (needs T003)
+Then:             T012 (needs T004), T013 (needs T008)
+```
+
+### US1 + US2 (can run concurrently — different file sets)
+
+```
+Agent A (US1): T014 → T015 → T016 → T017 → T018
+Agent B (US2): T019, T020, T021 (all parallel — different files)
+```
+
+### US3 + US4 (can run concurrently — different file sets)
+
+```
+Agent A (US3): T022, T023, T024 (parallel) → T025
+Agent B (US4): T026, T027, T028 (parallel) → T029 → T030
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (**CRITICAL — blocks all stories**)
+3. Complete Phase 3: US1 — Controller Simplification
+4. **STOP and VALIDATE**: Run test suite, check controller line counts, verify SSE event sequence
+5. Controllers are clean, prompts externalized, SSE abstracted — ready for demo
+
+### Incremental Delivery
+
+1. Setup + Foundational → all new modules exist and tested
+2. US1 (Controller Simplification) → slim controllers, clean services (MVP)
+3. US2 (Provider Dedup) → shared utils integrated, zero duplication
+4. US3 (Logging) → full observability with correlation IDs
+5. US4 (Auto-Registration) → open/closed provider pattern
+6. Polish → full verification against success criteria
+
+### Parallel Team Strategy
+
+With two developers after Foundational:
+- **Developer A**: US1 → US3 (controllers → logging on those controllers)
+- **Developer B**: US2 → US4 (providers → auto-registration of those providers)
+
+---
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total tasks | 34 |
+| Setup | 1 |
+| Foundational | 12 |
+| US1 (P1) | 5 |
+| US2 (P1) | 3 |
+| US3 (P2) | 4 |
+| US4 (P2) | 5 |
+| US5 (P3) | 0 (covered by Foundational + US1) |
+| US6 (P3) | 0 (covered by Foundational + US1) |
+| Polish | 4 |
+| Parallel opportunities | 3 major (Foundational groups, US1+US2, US3+US4) |
+| Suggested MVP scope | Phases 1-3 (Setup + Foundational + US1 = 18 tasks) |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks in the same phase
+- [Story] label maps task to specific user story for traceability
+- All refactored code MUST maintain existing API contracts (FR-009) — no changes to request/response shapes or SSE event types
+- No database schema changes — this is a purely structural refactor
+- Commit after each task or logical group
+- Stop at any checkpoint to validate independently

--- a/specs/002-backend-refactor/tasks.md
+++ b/specs/002-backend-refactor/tasks.md
@@ -19,7 +19,7 @@
 
 **Purpose**: Create new directory structure for modules introduced by this refactor
 
-- [ ] T001 Create new directories: backend/src/prompts/, backend/src/sse/, backend/tests/sse/
+- [X] T001 Create new directories: backend/src/prompts/, backend/src/sse/, backend/tests/sse/
 
 ---
 
@@ -29,18 +29,18 @@
 
 **Serves**: US5 (SSEWriter, SSE types), US6 (PromptLoader, prompt files), US2 (shared conversion utils), US4 (ProviderRegistration types), US3 (correlation ID propagation), US1 (incrementThreadTokens relocation)
 
-- [ ] T002 [P] Define ProviderRegistration, ModelConfig, and ProviderCapabilities interfaces with register() export convention in backend/src/providers/types.ts
-- [ ] T003 [P] Create SSE event type definitions (MessageStartEvent, DeltaEvent, ToolUseStartEvent, ToolUseResultEvent, MessageStopEvent, ErrorEvent) in backend/src/sse/types.ts
-- [ ] T004 [P] Create shared message conversion utilities (extractTextContent, mapToolResult, buildToolCallContentBlock) in backend/src/providers/utils.ts
-- [ ] T005 [P] Create default tool-capable system prompt as a parameterized template literal (date, timezone) in backend/src/prompts/default.ts
-- [ ] T006 [P] Create simple non-tool system prompt as a parameterized template literal in backend/src/prompts/simple.ts
-- [ ] T007 Create prompt loader getSystemPrompt({ supportsTools, date?, timezone? }) in backend/src/prompts/index.ts
-- [ ] T008 Create SSEWriter class with typed event methods (sendMessageStart, sendDelta, sendToolUseStart, sendToolUseResult, sendMessageStop, sendError, end) and client disconnect protection in backend/src/sse/sseWriter.ts
-- [ ] T009 Re-export SSE types from backend/src/types/events.ts pointing to backend/src/sse/types.ts for backward compatibility
-- [ ] T010 [P] Update requestLogger middleware to attach correlation ID (req.id) for downstream propagation in backend/src/middleware/requestLogger.ts
-- [ ] T011 [P] Move incrementThreadTokens function from messageService to threadService and update import in call site in backend/src/services/threadService.ts
-- [ ] T012 Write unit tests for extractTextContent, mapToolResult, and buildToolCallContentBlock including unknown content block passthrough in backend/tests/providers/utils.test.ts
-- [ ] T013 Write unit tests for SSEWriter including event formatting, connection state tracking, and write-after-close protection in backend/tests/sse/sseWriter.test.ts
+- [X] T002 [P] Define ProviderRegistration, ModelConfig, and ProviderCapabilities interfaces with register() export convention in backend/src/providers/types.ts
+- [X] T003 [P] Create SSE event type definitions (MessageStartEvent, DeltaEvent, ToolUseStartEvent, ToolUseResultEvent, MessageStopEvent, ErrorEvent) in backend/src/sse/types.ts
+- [X] T004 [P] Create shared message conversion utilities (extractTextContent, mapToolResult, buildToolCallContentBlock) in backend/src/providers/utils.ts
+- [X] T005 [P] Create default tool-capable system prompt as a parameterized template literal (date, timezone) in backend/src/prompts/default.ts
+- [X] T006 [P] Create simple non-tool system prompt as a parameterized template literal in backend/src/prompts/simple.ts
+- [X] T007 Create prompt loader getSystemPrompt({ supportsTools, date?, timezone? }) in backend/src/prompts/index.ts
+- [X] T008 Create SSEWriter class with typed event methods (sendMessageStart, sendDelta, sendToolUseStart, sendToolUseResult, sendMessageStop, sendError, end) and client disconnect protection in backend/src/sse/sseWriter.ts
+- [X] T009 Re-export SSE types from backend/src/types/events.ts pointing to backend/src/sse/types.ts for backward compatibility
+- [X] T010 [P] Update requestLogger middleware to attach correlation ID (req.id) for downstream propagation in backend/src/middleware/requestLogger.ts
+- [X] T011 [P] Move incrementThreadTokens function from messageService to threadService and update import in call site in backend/src/services/threadService.ts
+- [X] T012 Write unit tests for extractTextContent, mapToolResult, and buildToolCallContentBlock including unknown content block passthrough in backend/tests/providers/utils.test.ts
+- [X] T013 Write unit tests for SSEWriter including event formatting, connection state tracking, and write-after-close protection in backend/tests/sse/sseWriter.test.ts
 
 **Checkpoint**: All new modules exist and pass their tests. No existing behavior changed yet.
 
@@ -54,11 +54,11 @@
 
 ### Implementation for User Story 1
 
-- [ ] T014 [US1] Decompose contextService.buildContextWindow into focused helper methods (lookupCache, fetchMessages, applyTokenBudget, enforceMinimumMessages, enforceRoleAlternation, validateLastRole) in backend/src/services/contextService.ts
-- [ ] T015 [US1] Refactor chatService to use PromptLoader for system prompts and accept SSEWriter callbacks for event emission, removing embedded prompt text and inline res.write calls in backend/src/services/chatService.ts
-- [ ] T016 [US1] Slim messageController.handleSendMessage to ~25 lines: validate input, create SSEWriter, delegate to chatService, handle completion in backend/src/controllers/messageController.ts
-- [ ] T017 [US1] Standardize threadController error handling: replace all manual res.status().json() patterns with throw AppError exclusively in backend/src/controllers/threadController.ts
-- [ ] T018 [US1] Update contextService tests to cover decomposed helper methods (lookupCache, fetchMessages, applyTokenBudget, enforceRoleAlternation) in backend/tests/services/contextService.test.ts
+- [X] T014 [US1] Decompose contextService.buildContextWindow into focused helper methods (lookupCache, fetchMessages, applyTokenBudget, enforceMinimumMessages, enforceRoleAlternation, validateLastRole) in backend/src/services/contextService.ts
+- [X] T015 [US1] Refactor chatService to use PromptLoader for system prompts and accept SSEWriter callbacks for event emission, removing embedded prompt text and inline res.write calls in backend/src/services/chatService.ts
+- [X] T016 [US1] Slim messageController.handleSendMessage to ~25 lines: validate input, create SSEWriter, delegate to chatService, handle completion in backend/src/controllers/messageController.ts
+- [X] T017 [US1] Standardize threadController error handling: replace all manual res.status().json() patterns with throw AppError exclusively in backend/src/controllers/threadController.ts
+- [X] T018 [US1] Update contextService tests to cover decomposed helper methods (lookupCache, fetchMessages, applyTokenBudget, enforceRoleAlternation) in backend/tests/services/contextService.test.ts
 
 **Checkpoint**: Controllers are slim orchestrators. `handleSendMessage` is ~25 lines. All existing tests pass unmodified.
 
@@ -72,9 +72,9 @@
 
 ### Implementation for User Story 2
 
-- [ ] T019 [P] [US2] Refactor OpenAI provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/openai.ts
-- [ ] T020 [P] [US2] Refactor Google provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/google.ts
-- [ ] T021 [P] [US2] Refactor Ollama provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/ollama.ts
+- [X] T019 [P] [US2] Refactor OpenAI provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/openai.ts
+- [X] T020 [P] [US2] Refactor Google provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/google.ts
+- [X] T021 [P] [US2] Refactor Ollama provider to use extractTextContent and mapToolResult from shared utils, removing inline text-block filtering and tool result detection in backend/src/providers/ollama.ts
 
 **Checkpoint**: Text extraction logic (`.filter(b => b.type === 'text')...`) exists in exactly one location. Each provider's `chatCompletion` contains only provider-specific API calls.
 
@@ -88,10 +88,10 @@
 
 ### Implementation for User Story 3
 
-- [ ] T022 [P] [US3] Add structured logging with operation name, entity IDs, duration, and child logger (requestId) to all five threadController handlers in backend/src/controllers/threadController.ts
-- [ ] T023 [P] [US3] Add error logging with err object, statusCode, and correlation ID to errorHandler middleware in backend/src/middleware/errorHandler.ts
-- [ ] T024 [P] [US3] Add operation timing (Date.now delta) and correlation ID via logger.child({ requestId }) to messageController handlers in backend/src/controllers/messageController.ts
-- [ ] T025 [US3] Enhance tool execution logging with tool name, duration, input size, output size, success/failure status, and correlation ID in backend/src/services/toolExecutor.ts
+- [X] T022 [P] [US3] Add structured logging with operation name, entity IDs, duration, and child logger (requestId) to all five threadController handlers in backend/src/controllers/threadController.ts
+- [X] T023 [P] [US3] Add error logging with err object, statusCode, and correlation ID to errorHandler middleware in backend/src/middleware/errorHandler.ts
+- [X] T024 [P] [US3] Add operation timing (Date.now delta) and correlation ID via logger.child({ requestId }) to messageController handlers in backend/src/controllers/messageController.ts
+- [X] T025 [US3] Enhance tool execution logging with tool name, duration, input size, output size, success/failure status, and correlation ID in backend/src/services/toolExecutor.ts
 
 **Checkpoint**: Thread controller has structured logging (was zero). All controller operations include duration. Correlation ID traces from controller through tool execution.
 
@@ -105,11 +105,11 @@
 
 ### Implementation for User Story 4
 
-- [ ] T026 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to OpenAI provider in backend/src/providers/openai.ts
-- [ ] T027 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to Google provider in backend/src/providers/google.ts
-- [ ] T028 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to Ollama provider in backend/src/providers/ollama.ts
-- [ ] T029 [US4] Implement auto-registration: scan providers/ directory for .ts files (excluding index.ts, types.ts, utils.ts), call each register(), populate MODEL_REGISTRY and factory map, reject duplicate names in backend/src/providers/index.ts
-- [ ] T030 [US4] Update server.ts to call provider auto-registration at startup and log registered providers in backend/src/server.ts
+- [X] T026 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to OpenAI provider in backend/src/providers/openai.ts
+- [X] T027 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to Google provider in backend/src/providers/google.ts
+- [X] T028 [P] [US4] Add register() export function returning ProviderRegistration { name, models, capabilities, factory } to Ollama provider in backend/src/providers/ollama.ts
+- [X] T029 [US4] Implement auto-registration: scan providers/ directory for .ts files (excluding index.ts, types.ts, utils.ts), call each register(), populate MODEL_REGISTRY and factory map, reject duplicate names in backend/src/providers/index.ts
+- [X] T030 [US4] Update server.ts to call provider auto-registration at startup and log registered providers in backend/src/server.ts
 
 **Checkpoint**: Removing a provider file and restarting → provider absent, no errors. Adding a file with register() → provider available. Duplicate name → startup error.
 
@@ -154,10 +154,10 @@ No additional tasks required.
 
 **Purpose**: Final verification that the refactor maintains all contracts and meets success criteria
 
-- [ ] T031 [P] Run full backend test suite to verify all existing tests pass without modification (SC-005)
-- [ ] T032 [P] Audit all functions to verify none exceeds 50 lines (SC-006) and no controller handler exceeds 30 lines (SC-001)
-- [ ] T033 Run quickstart.md verification checklist: API contracts, SSE event sequence, tool calling, provider verification, logging verification
-- [ ] T034 Verify message format conversion code exists in exactly one shared location with zero duplication across providers (SC-002)
+- [X] T031 [P] Run full backend test suite to verify all existing tests pass without modification (SC-005)
+- [X] T032 [P] Audit all functions to verify none exceeds 50 lines (SC-006) and no controller handler exceeds 30 lines (SC-001)
+- [X] T033 Run quickstart.md verification checklist: API contracts, SSE event sequence, tool calling, provider verification, logging verification
+- [X] T034 Verify message format conversion code exists in exactly one shared location with zero duplication across providers (SC-002)
 
 ---
 


### PR DESCRIPTION
Overhauls the backend with clean architecture (providers, tool system,
error hierarchy, slim controllers). Adds Ollama streaming with per-token
onDelta callbacks and agentic loop refinements. Migrates frontend to
URL-based routing via react-router-dom. Upgrades Node to 22 with
healthier Docker startup.

Highlights:
- Backend: Anthropic-style provider interface, RunnableTool pattern,
  auto-registering providers, correlation IDs, structured logging
- Ollama: streaming chatCompletion with real-time delta callbacks,
  timeout handling, fixes for double-fire and Promise hangs
- Agentic loop: onDelta threaded through, tool output truncated at 10K,
  parallel tool execution, max 10 iterations
- Routing: App refactored with BrowserRouter, ChatLayout, ChatContainer
  reads thread ID from URL params
- Infra: Node 22 (Docker + tsconfig), postgres healthcheck before backend
  starts, Prisma binary targets for musl
- Docs: AGENTS.md with repo gotchas for OpenCode sessions