### PR TITLE
feat: Gmail automation agent with OAuth and 5 email tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules
 */uploads
 *.playwright-mcp
 
+# Gmail OAuth tokens
+.gmail-tokens.json
+
 # Build artifacts
 dist/
 build/

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/003-gmail-agent"
+}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,8 @@ BASE_URL="http://localhost:3000"
 OPENAI_API_KEY= <#PUT_YOUR_KEY_HERE#>
 GOOGLE_API_KEY=<#PUT_YOUR_KEY_HERE#>
 SEARXNG_URL=http://localhost:8888
+# Google OAuth2 (used by Calendar + Gmail tools)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# Calendar only — Gmail uses file-based tokens via OAuth flow
 GOOGLE_REFRESH_TOKEN=

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,6 +35,7 @@
         "eslint": "^9.2.0",
         "globals": "^15.1.0",
         "jest": "^29.7.0",
+        "jest-util": "^29.7.0",
         "nodemon": "^3.1.14",
         "pino-pretty": "^13.1.3",
         "prisma": "^5.22.0",
@@ -830,78 +831,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/console/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/console/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/console/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jest/console/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/core": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
@@ -950,19 +879,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/core/node_modules/@jest/transform": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
@@ -990,24 +906,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/core/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/core/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
@@ -1018,13 +916,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jest/core/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -1039,22 +930,6 @@
         "istanbul-lib-instrument": "^5.0.4",
         "test-exclude": "^6.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1108,24 +983,6 @@
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1199,44 +1056,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/environment/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/environment/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/environment/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
@@ -1282,78 +1101,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/fake-timers/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jest/fake-timers/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/fake-timers/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -1369,44 +1116,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/@jest/globals/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/globals/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/globals/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
@@ -1452,19 +1161,6 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/@jest/transform": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
@@ -1492,24 +1188,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/reporters/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
@@ -1520,13 +1198,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jest/reporters/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -1558,22 +1229,6 @@
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^6.3.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1610,24 +1265,6 @@
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1685,6 +1322,19 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
@@ -1727,44 +1377,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/test-result/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-result/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-result/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
@@ -1779,60 +1391,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jest/test-sequencer/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/test-sequencer/node_modules/jest-haste-map": {
@@ -1871,24 +1429,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/test-sequencer/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/test-sequencer/node_modules/jest-worker": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
@@ -1919,6 +1459,24 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2137,6 +1695,13 @@
       "funding": {
         "url": "https://ko-fi.com/killymxi"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -3091,6 +2656,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -3291,78 +2872,6 @@
       },
       "bin": {
         "create-jest": "bin/create-jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/create-jest/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/create-jest/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/create-jest/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/create-jest/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/create-jest/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4013,78 +3522,6 @@
         "jest-matcher-utils": "^29.7.0",
         "jest-message-util": "^29.7.0",
         "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/expect/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/expect/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5225,78 +4662,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-changed-files/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-changed-files/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-circus": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
@@ -5324,78 +4689,6 @@
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-circus/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-circus/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5433,78 +4726,6 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-cli/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-config": {
@@ -5553,19 +4774,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/@jest/transform": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
@@ -5593,24 +4801,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-config/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
@@ -5621,13 +4811,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/jest-config/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-config/node_modules/babel-jest": {
       "version": "29.7.0",
@@ -5701,22 +4884,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/jest-config/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-config/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
@@ -5766,24 +4933,6 @@
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -5887,78 +5036,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-each/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-each/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-each/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -5972,78 +5049,6 @@
         "@types/node": "*",
         "jest-mock": "^29.7.0",
         "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-environment-node/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6110,44 +5115,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-message-util/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-mock": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
@@ -6158,78 +5125,6 @@
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-mock/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-mock/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6298,60 +5193,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-resolve/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-resolve/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-resolve/node_modules/jest-haste-map": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
@@ -6384,24 +5225,6 @@
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -6471,19 +5294,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runner/node_modules/@jest/transform": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
@@ -6511,24 +5321,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runner/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
@@ -6539,13 +5331,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/jest-runner/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-runner/node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -6560,22 +5345,6 @@
         "istanbul-lib-instrument": "^5.0.4",
         "test-exclude": "^6.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runner/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6629,24 +5398,6 @@
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -6738,19 +5489,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/@jest/transform": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
@@ -6778,24 +5516,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
@@ -6806,13 +5526,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/jest-runtime/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -6827,22 +5540,6 @@
         "istanbul-lib-instrument": "^5.0.4",
         "test-exclude": "^6.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6896,24 +5593,6 @@
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -7003,19 +5682,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/@jest/transform": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
@@ -7043,24 +5709,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
@@ -7071,13 +5719,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/jest-snapshot/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -7092,22 +5733,6 @@
         "istanbul-lib-instrument": "^5.0.4",
         "test-exclude": "^6.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7171,24 +5796,6 @@
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -7259,6 +5866,24 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -7276,44 +5901,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-validate/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
@@ -7347,116 +5934,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-watcher/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-watcher/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -8548,26 +7025,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/pretty-format/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "eslint": "^9.2.0",
     "globals": "^15.1.0",
     "jest": "^29.7.0",
+    "jest-util": "^29.7.0",
     "nodemon": "^3.1.14",
     "pino-pretty": "^13.1.3",
     "prisma": "^5.22.0",

--- a/backend/src/config/logger.ts
+++ b/backend/src/config/logger.ts
@@ -7,7 +7,16 @@ const logger = pino({
 
   // Redact sensitive fields from logs
   redact: {
-    paths: ['apiKey', 'req.headers.authorization', 'req.headers.cookie'],
+    paths: [
+      'apiKey',
+      'req.headers.authorization',
+      'req.headers.cookie',
+      'emailBody',
+      'emailSubject',
+      'emailContent',
+      'body',
+      'subject',
+    ],
     censor: '[REDACTED]',
   },
 

--- a/backend/src/prompts/default.ts
+++ b/backend/src/prompts/default.ts
@@ -11,6 +11,11 @@ CRITICAL RULES - FOLLOW EXACTLY:
    - Calendar/schedule → google_calendar
    - Websites/URLs → fetch_url
    - Math calculations → calculator
+   - Read/list emails → read_emails
+   - Search emails → search_emails
+   - Summarize inbox → summarize_emails
+   - Draft new email → draft_email
+   - Reply to email → reply_email
 
 3. When a tool returns results, you MUST synthesize them into a helpful answer:
    - web_search → Read ALL results, filter relevant ones, write a natural summary (NOT a numbered list)

--- a/backend/src/routes/gmailAuthRoutes.ts
+++ b/backend/src/routes/gmailAuthRoutes.ts
@@ -1,0 +1,104 @@
+import { Router, Request, Response } from 'express';
+import { emailService } from '../services/emailService';
+import { authMiddleware } from '../middleware/auth';
+import logger from '../config/logger';
+
+const log = logger.child({ route: 'gmailAuth' });
+
+export const gmailAuthRoutes = Router();
+
+gmailAuthRoutes.get('/auth/gmail', authMiddleware, (req: Request, res: Response) => {
+  try {
+    const oauth2 = emailService.createOAuth2Client();
+    const authorizeUrl = oauth2.generateAuthUrl({
+      access_type: 'offline',
+      prompt: 'consent',
+      scope: emailService.getScopes(),
+      state: req.user!.id,
+    });
+    res.redirect(authorizeUrl);
+  } catch (err: any) {
+    log.error({ err }, 'OAuth initiation failed');
+    res.status(500).json({
+      error: { type: 'internal_error', message: err.message },
+    });
+  }
+});
+
+gmailAuthRoutes.get('/auth/gmail/callback', async (req: Request, res: Response) => {
+  const { code, state, error } = req.query;
+
+  if (error) {
+    res.status(400).json({
+      error: { type: 'bad_request', message: 'Authorization denied by user.' },
+    });
+    return;
+  }
+
+  if (!code || typeof code !== 'string') {
+    res.status(400).json({
+      error: { type: 'bad_request', message: 'Missing authorization code.' },
+    });
+    return;
+  }
+
+  const userId = typeof state === 'string' ? state : '';
+  if (!userId) {
+    res.status(400).json({
+      error: { type: 'bad_request', message: 'Missing state parameter.' },
+    });
+    return;
+  }
+
+  try {
+    const oauth2 = emailService.createOAuth2Client();
+    const { tokens } = await oauth2.getToken(code);
+
+    oauth2.setCredentials(tokens);
+    const gmail = (await import('googleapis')).google.gmail({ version: 'v1', auth: oauth2 });
+    const profile = await gmail.users.getProfile({ userId: 'me' });
+    const email = profile.data.emailAddress ?? '';
+
+    emailService.saveTokens(userId, {
+      accessToken: tokens.access_token!,
+      refreshToken: tokens.refresh_token!,
+      expiryDate: tokens.expiry_date!,
+      scopes: (tokens.scope ?? '').split(' '),
+      email,
+      obtainedAt: new Date().toISOString(),
+    });
+
+    log.info({ userId, email }, 'Gmail OAuth complete');
+
+    res.status(200).send(`
+      <html>
+      <body>
+        <h1>Gmail Connected</h1>
+        <p>You can close this window and return to the chat.</p>
+      </body>
+      </html>
+    `);
+  } catch (err: any) {
+    log.error({ err, userId }, 'Token exchange failed');
+    res.status(500).json({
+      error: { type: 'internal_error', message: 'Token exchange failed.' },
+    });
+  }
+});
+
+gmailAuthRoutes.get('/auth/gmail/status', authMiddleware, async (req: Request, res: Response) => {
+  const userId = req.user!.id;
+  const tokens = emailService.getTokens(userId);
+
+  if (!tokens) {
+    res.json({ connected: false, authorizeUrl: '/api/v1/auth/gmail' });
+    return;
+  }
+
+  res.json({
+    connected: true,
+    email: tokens.email,
+    scopes: tokens.scopes,
+    connectedAt: tokens.obtainedAt,
+  });
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import { requestLogger } from './middleware/requestLogger';
 import { errorHandler } from './middleware/errorHandler';
 import { threadRoutes } from './routes/threadRoutes';
 import { messageRoutes } from './routes/messageRoutes';
+import { gmailAuthRoutes } from './routes/gmailAuthRoutes';
 import { registerAllTools } from './tools';
 import { toolRegistry } from './services/toolRegistry';
 import { registerProviders } from './providers';
@@ -23,6 +24,9 @@ const port = process.env.PORT || 5001;
 app.use(cors());
 app.use(express.json({ limit: '20mb' }));
 app.use(requestLogger);
+
+// Gmail OAuth routes (callback must be accessible without auth — middleware applied per-route)
+app.use('/api/v1', gmailAuthRoutes);
 
 // API v1 routes (with auth)
 app.use('/api/v1', authMiddleware);

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -1,0 +1,476 @@
+import fs from 'fs';
+import path from 'path';
+import { google, gmail_v1 } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+import { convert } from 'html-to-text';
+import logger from '../config/logger';
+import {
+  GmailTokenStore,
+  GmailTokenEntry,
+  EmailSummary,
+  AttachmentMeta,
+  EmailDraft,
+  DraftResult,
+  EmailListResult,
+} from '../types/email';
+
+const log = logger.child({ service: 'emailService' });
+const TOKEN_FILE = path.join(__dirname, '../../.gmail-tokens.json');
+const MAX_BODY_BYTES = 50 * 1024;
+const SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.compose',
+];
+
+class EmailService {
+  private static instance: EmailService;
+
+  static getInstance(): EmailService {
+    if (!EmailService.instance) {
+      EmailService.instance = new EmailService();
+    }
+    return EmailService.instance;
+  }
+
+  getScopes(): string[] {
+    return SCOPES;
+  }
+
+  getRedirectUri(): string {
+    return 'http://localhost:5001/api/v1/auth/gmail/callback';
+  }
+
+  createOAuth2Client(): OAuth2Client {
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    if (!clientId || !clientSecret) {
+      throw new Error('Google OAuth not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.');
+    }
+    return new google.auth.OAuth2(clientId, clientSecret, this.getRedirectUri());
+  }
+
+  // ─── Token CRUD ───
+
+  getTokens(userId: string): GmailTokenEntry | null {
+    const store = this.readTokenFile();
+    return store[userId] ?? null;
+  }
+
+  saveTokens(userId: string, tokens: GmailTokenEntry): void {
+    const store = this.readTokenFile();
+    store[userId] = tokens;
+    fs.writeFileSync(TOKEN_FILE, JSON.stringify(store, null, 2));
+    log.info({ userId }, 'Gmail tokens saved');
+  }
+
+  removeTokens(userId: string): void {
+    const store = this.readTokenFile();
+    delete store[userId];
+    fs.writeFileSync(TOKEN_FILE, JSON.stringify(store, null, 2));
+    log.info({ userId }, 'Gmail tokens removed');
+  }
+
+  isConnected(userId: string): boolean {
+    return this.getTokens(userId) !== null;
+  }
+
+  private readTokenFile(): GmailTokenStore {
+    try {
+      if (!fs.existsSync(TOKEN_FILE)) return {};
+      const data = fs.readFileSync(TOKEN_FILE, 'utf-8');
+      return JSON.parse(data);
+    } catch {
+      return {};
+    }
+  }
+
+  // ─── Auth Client ───
+
+  async getAuthClient(userId: string): Promise<OAuth2Client> {
+    const entry = this.getTokens(userId);
+    if (!entry) {
+      throw new Error('Gmail not connected. Visit /api/v1/auth/gmail to authorize.');
+    }
+
+    const oauth2 = this.createOAuth2Client();
+    oauth2.setCredentials({
+      access_token: entry.accessToken,
+      refresh_token: entry.refreshToken,
+      expiry_date: entry.expiryDate,
+    });
+
+    if (Date.now() >= entry.expiryDate) {
+      log.info({ userId }, 'Access token expired, refreshing');
+      try {
+        const { credentials } = await oauth2.refreshAccessToken();
+        this.saveTokens(userId, {
+          ...entry,
+          accessToken: credentials.access_token!,
+          expiryDate: credentials.expiry_date!,
+        });
+        oauth2.setCredentials(credentials);
+      } catch (err: any) {
+        log.error({ userId, err }, 'Token refresh failed');
+        this.removeTokens(userId);
+        throw new Error('Gmail authorization expired. Visit /api/v1/auth/gmail to re-authorize.');
+      }
+    }
+
+    return oauth2;
+  }
+
+  // ─── Retry Wrapper ───
+
+  private async withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        return await fn();
+      } catch (err: any) {
+        const is429 = err?.code === 429 || err?.response?.status === 429;
+        if (!is429 || attempt === retries) throw err;
+        const delay = Math.pow(2, attempt) * 1000;
+        log.warn({ attempt: attempt + 1, delay }, 'Rate limited, retrying');
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+    throw new Error('Retry exhausted');
+  }
+
+  // ─── Email Parsing ───
+
+  parseEmail(message: gmail_v1.Schema$Message): EmailSummary {
+    const headers = message.payload?.headers ?? [];
+    const getHeader = (name: string) =>
+      headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value ?? '';
+
+    const fromRaw = getHeader('From');
+    const fromMatch = fromRaw.match(/^(.+?)\s*<(.+?)>$/);
+    const from = fromMatch
+      ? { name: fromMatch[1].replace(/"/g, '').trim(), address: fromMatch[2] }
+      : { name: '', address: fromRaw };
+
+    const toRaw = getHeader('To');
+    const to = toRaw
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    const labels = message.labelIds ?? [];
+    const attachments = this.extractAttachments(message.payload);
+
+    return {
+      id: message.id!,
+      threadId: message.threadId!,
+      from,
+      to,
+      subject: getHeader('Subject'),
+      date: getHeader('Date'),
+      snippet: message.snippet ?? '',
+      isUnread: labels.includes('UNREAD'),
+      hasAttachments: attachments.length > 0,
+      attachments: attachments.length > 0 ? attachments : undefined,
+      labels,
+    };
+  }
+
+  extractBody(payload: gmail_v1.Schema$MessagePart | undefined): string {
+    if (!payload) return '';
+
+    if (payload.mimeType === 'text/plain' && payload.body?.data) {
+      return Buffer.from(payload.body.data, 'base64url').toString('utf-8');
+    }
+
+    if (payload.mimeType === 'text/html' && payload.body?.data) {
+      const html = Buffer.from(payload.body.data, 'base64url').toString('utf-8');
+      return convert(html, { wordwrap: 120 });
+    }
+
+    if (payload.parts) {
+      const textPart = payload.parts.find((p) => p.mimeType === 'text/plain');
+      if (textPart) return this.extractBody(textPart);
+
+      const htmlPart = payload.parts.find((p) => p.mimeType === 'text/html');
+      if (htmlPart) return this.extractBody(htmlPart);
+
+      for (const part of payload.parts) {
+        const result = this.extractBody(part);
+        if (result) return result;
+      }
+    }
+
+    return '';
+  }
+
+  truncateBody(text: string, maxBytes: number = MAX_BODY_BYTES): string {
+    const buf = Buffer.from(text, 'utf-8');
+    if (buf.length <= maxBytes) return text;
+    const truncated = buf.subarray(0, maxBytes).toString('utf-8');
+    return truncated + '\n[truncated]';
+  }
+
+  private extractAttachments(payload: gmail_v1.Schema$MessagePart | undefined): AttachmentMeta[] {
+    const attachments: AttachmentMeta[] = [];
+    if (!payload) return attachments;
+
+    if (payload.filename && payload.filename.length > 0 && payload.body) {
+      attachments.push({
+        filename: payload.filename,
+        mimeType: payload.mimeType ?? 'application/octet-stream',
+        size: payload.body.size ?? 0,
+      });
+    }
+
+    if (payload.parts) {
+      for (const part of payload.parts) {
+        attachments.push(...this.extractAttachments(part));
+      }
+    }
+
+    return attachments;
+  }
+
+  // ─── List Emails ───
+
+  async listEmails(
+    userId: string,
+    filter: 'unread' | 'read' | 'all' = 'unread',
+    maxResults: number = 20,
+    dateRange?: { after?: string; before?: string },
+    includeBody: boolean = false,
+  ): Promise<EmailListResult> {
+    const auth = await this.getAuthClient(userId);
+    const gmail = google.gmail({ version: 'v1', auth });
+
+    const queryParts: string[] = [];
+    if (filter === 'unread') queryParts.push('is:unread');
+    else if (filter === 'read') queryParts.push('is:read');
+    if (dateRange?.after) queryParts.push(`after:${this.formatDateForQuery(dateRange.after)}`);
+    if (dateRange?.before) queryParts.push(`before:${this.formatDateForQuery(dateRange.before)}`);
+
+    const q = queryParts.join(' ') || undefined;
+
+    const listResponse = await this.withRetry(() =>
+      gmail.users.messages.list({ userId: 'me', q, maxResults }),
+    );
+
+    const messageIds = listResponse.data.messages ?? [];
+    const totalCount = listResponse.data.resultSizeEstimate ?? messageIds.length;
+
+    const emails: EmailSummary[] = [];
+    for (const msg of messageIds) {
+      const detail = await this.withRetry(() =>
+        gmail.users.messages.get({
+          userId: 'me',
+          id: msg.id!,
+          format: includeBody ? 'full' : 'metadata',
+          metadataHeaders: ['From', 'To', 'Subject', 'Date'],
+        }),
+      );
+      const summary = this.parseEmail(detail.data);
+      if (includeBody) {
+        const rawBody = this.extractBody(detail.data.payload);
+        summary.body = this.truncateBody(rawBody);
+      }
+      emails.push(summary);
+    }
+
+    return { emails, totalCount, returnedCount: emails.length };
+  }
+
+  // ─── Get Single Email ───
+
+  async getEmail(userId: string, emailId: string, includeBody: boolean = false): Promise<EmailSummary> {
+    const auth = await this.getAuthClient(userId);
+    const gmail = google.gmail({ version: 'v1', auth });
+
+    const detail = await this.withRetry(() =>
+      gmail.users.messages.get({ userId: 'me', id: emailId, format: 'full' }),
+    );
+
+    const summary = this.parseEmail(detail.data);
+    if (includeBody) {
+      const rawBody = this.extractBody(detail.data.payload);
+      summary.body = this.truncateBody(rawBody);
+    }
+
+    return summary;
+  }
+
+  // ─── Search Emails ───
+
+  async searchEmails(
+    userId: string,
+    params: {
+      from?: string;
+      to?: string;
+      subject?: string;
+      keywords?: string;
+      dateRange?: { after?: string; before?: string };
+      hasAttachment?: boolean;
+      maxResults?: number;
+      includeBody?: boolean;
+    },
+  ): Promise<EmailListResult> {
+    const queryParts: string[] = [];
+    if (params.from) queryParts.push(`from:${params.from}`);
+    if (params.to) queryParts.push(`to:${params.to}`);
+    if (params.subject) queryParts.push(`subject:${params.subject}`);
+    if (params.keywords) queryParts.push(params.keywords);
+    if (params.dateRange?.after) queryParts.push(`after:${this.formatDateForQuery(params.dateRange.after)}`);
+    if (params.dateRange?.before) queryParts.push(`before:${this.formatDateForQuery(params.dateRange.before)}`);
+    if (params.hasAttachment) queryParts.push('has:attachment');
+
+    const auth = await this.getAuthClient(userId);
+    const gmail = google.gmail({ version: 'v1', auth });
+    const maxResults = params.maxResults ?? 20;
+    const q = queryParts.join(' ') || undefined;
+
+    const listResponse = await this.withRetry(() =>
+      gmail.users.messages.list({ userId: 'me', q, maxResults }),
+    );
+
+    const messageIds = listResponse.data.messages ?? [];
+    const totalCount = listResponse.data.resultSizeEstimate ?? messageIds.length;
+
+    const emails: EmailSummary[] = [];
+    for (const msg of messageIds) {
+      const detail = await this.withRetry(() =>
+        gmail.users.messages.get({
+          userId: 'me',
+          id: msg.id!,
+          format: params.includeBody ? 'full' : 'metadata',
+          metadataHeaders: ['From', 'To', 'Subject', 'Date'],
+        }),
+      );
+      const summary = this.parseEmail(detail.data);
+      if (params.includeBody) {
+        const rawBody = this.extractBody(detail.data.payload);
+        summary.body = this.truncateBody(rawBody);
+      }
+      emails.push(summary);
+    }
+
+    return { emails, totalCount, returnedCount: emails.length };
+  }
+
+  // ─── Create Draft ───
+
+  async createDraft(userId: string, draft: EmailDraft): Promise<DraftResult> {
+    const auth = await this.getAuthClient(userId);
+    const gmail = google.gmail({ version: 'v1', auth });
+
+    const mime = this.buildMimeMessage(draft);
+    const encodedMessage = Buffer.from(mime).toString('base64url');
+
+    const response = await this.withRetry(() =>
+      gmail.users.drafts.create({
+        userId: 'me',
+        requestBody: { message: { raw: encodedMessage } },
+      }),
+    );
+
+    log.info({ userId, draftId: response.data.id }, 'Draft created');
+
+    return {
+      draftId: response.data.id!,
+      threadId: response.data.message?.threadId ?? '',
+      to: draft.to,
+      subject: draft.subject,
+      bodyPreview: draft.body.substring(0, 200),
+    };
+  }
+
+  // ─── Create Reply Draft ───
+
+  async createReplyDraft(userId: string, emailId: string, body: string): Promise<DraftResult> {
+    const auth = await this.getAuthClient(userId);
+    const gmail = google.gmail({ version: 'v1', auth });
+
+    const original = await this.withRetry(() =>
+      gmail.users.messages.get({ userId: 'me', id: emailId, format: 'metadata', metadataHeaders: ['From', 'To', 'Subject', 'Message-ID', 'References'] }),
+    );
+
+    const headers = original.data.payload?.headers ?? [];
+    const getHeader = (name: string) =>
+      headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value ?? '';
+
+    const originalFrom = getHeader('From');
+    const originalSubject = getHeader('Subject');
+    const messageId = getHeader('Message-ID');
+    const references = getHeader('References');
+    const threadId = original.data.threadId!;
+
+    const replySubject = originalSubject.startsWith('Re:') ? originalSubject : `Re: ${originalSubject}`;
+    const replyReferences = references ? `${references} ${messageId}` : messageId;
+
+    const fromMatch = originalFrom.match(/<(.+?)>/);
+    const replyTo = fromMatch ? fromMatch[1] : originalFrom;
+
+    const mime = this.buildReplyMimeMessage(
+      { to: replyTo, subject: replySubject, body },
+      messageId,
+      replyReferences,
+    );
+    const encodedMessage = Buffer.from(mime).toString('base64url');
+
+    const response = await this.withRetry(() =>
+      gmail.users.drafts.create({
+        userId: 'me',
+        requestBody: { message: { raw: encodedMessage, threadId } },
+      }),
+    );
+
+    log.info({ userId, draftId: response.data.id, threadId }, 'Reply draft created');
+
+    return {
+      draftId: response.data.id!,
+      threadId,
+      to: replyTo,
+      subject: replySubject,
+      bodyPreview: body.substring(0, 200),
+    };
+  }
+
+  // ─── MIME Helpers ───
+
+  private buildMimeMessage(draft: EmailDraft): string {
+    const lines: string[] = [
+      `To: ${draft.to}`,
+      `Subject: ${draft.subject}`,
+      'Content-Type: text/plain; charset=UTF-8',
+    ];
+    if (draft.cc) lines.push(`Cc: ${draft.cc}`);
+    if (draft.bcc) lines.push(`Bcc: ${draft.bcc}`);
+    lines.push('', draft.body);
+    return lines.join('\r\n');
+  }
+
+  private buildReplyMimeMessage(
+    draft: { to: string; subject: string; body: string },
+    inReplyTo: string,
+    references: string,
+  ): string {
+    return [
+      `To: ${draft.to}`,
+      `Subject: ${draft.subject}`,
+      `In-Reply-To: ${inReplyTo}`,
+      `References: ${references}`,
+      'Content-Type: text/plain; charset=UTF-8',
+      '',
+      draft.body,
+    ].join('\r\n');
+  }
+
+  // ─── Date Formatting ───
+
+  private formatDateForQuery(dateStr: string): string {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}/${m}/${day}`;
+  }
+}
+
+export const emailService = EmailService.getInstance();

--- a/backend/src/tools/draftEmail.ts
+++ b/backend/src/tools/draftEmail.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+import { RunnableTool } from './types';
+import { ToolError } from '../errors';
+import { emailService } from '../services/emailService';
+import logger from '../config/logger';
+
+const log = logger.child({ tool: 'draft_email' });
+
+const schema = z.object({
+  to: z.string().email().describe('Recipient email address'),
+  subject: z.string().min(1).describe('Email subject line'),
+  body: z.string().min(1).describe('Email body text'),
+  cc: z.string().optional().describe('CC email addresses (comma-separated)'),
+  bcc: z.string().optional().describe('BCC email addresses (comma-separated)'),
+});
+
+export const draftEmail: RunnableTool<z.infer<typeof schema>> = {
+  definition: {
+    name: 'draft_email',
+    description:
+      'Create an email draft in the user\'s Gmail. Use when the user asks to compose, write, or draft an email. The draft is saved to Gmail Drafts — it is NOT sent. The user must open Gmail to review and send.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'Recipient email address' },
+        subject: { type: 'string', description: 'Email subject line' },
+        body: { type: 'string', description: 'Email body text' },
+        cc: { type: 'string', description: 'CC email addresses (comma-separated)' },
+        bcc: { type: 'string', description: 'BCC email addresses (comma-separated)' },
+      },
+      required: ['to', 'subject', 'body'],
+    },
+  },
+  schema,
+  timeoutMs: 10000,
+
+  async run(input) {
+    const userId = '00000000-0000-0000-0000-000000000001';
+
+    if (!emailService.isConnected(userId)) {
+      throw new ToolError('Gmail not connected. Visit http://localhost:5001/api/v1/auth/gmail to authorize.');
+    }
+
+    try {
+      log.info({ to: input.to }, 'Creating email draft');
+      const result = await emailService.createDraft(userId, input);
+      log.info({ draftId: result.draftId }, 'Draft created');
+
+      return [
+        'Draft saved to Gmail.',
+        `  To: ${result.to}`,
+        `  Subject: ${result.subject}`,
+        `  Preview: ${result.bodyPreview}`,
+        `  Draft ID: ${result.draftId}`,
+        '',
+        'Open Gmail to review and send.',
+      ].join('\n');
+    } catch (err: any) {
+      log.error({ err }, 'Failed to create draft');
+      if (err.message?.includes('Gmail not connected') || err.message?.includes('Gmail authorization')) {
+        throw new ToolError(err.message);
+      }
+      throw new ToolError(`Failed to create draft: ${err.message}`);
+    }
+  },
+};

--- a/backend/src/tools/index.ts
+++ b/backend/src/tools/index.ts
@@ -4,6 +4,11 @@ import { webSearch } from './webSearch';
 import { fetchUrl } from './fetchUrl';
 import { googleCalendar } from './googleCalendar';
 import { getCurrentDate } from './getCurrentDate';
+import { readEmails } from './readEmails';
+import { searchEmails } from './searchEmails';
+import { summarizeEmails } from './summarizeEmails';
+import { draftEmail } from './draftEmail';
+import { replyEmail } from './replyEmail';
 
 export function registerAllTools(): void {
   toolRegistry.register(calculator);
@@ -11,4 +16,9 @@ export function registerAllTools(): void {
   toolRegistry.register(fetchUrl);
   toolRegistry.register(googleCalendar);
   toolRegistry.register(getCurrentDate);
+  toolRegistry.register(readEmails);
+  toolRegistry.register(searchEmails);
+  toolRegistry.register(summarizeEmails);
+  toolRegistry.register(draftEmail);
+  toolRegistry.register(replyEmail);
 }

--- a/backend/src/tools/readEmails.ts
+++ b/backend/src/tools/readEmails.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+import { RunnableTool } from './types';
+import { ToolError } from '../errors';
+import { emailService } from '../services/emailService';
+import { EmailSummary } from '../types/email';
+import logger from '../config/logger';
+
+const log = logger.child({ tool: 'read_emails' });
+
+const schema = z.object({
+  filter: z.enum(['unread', 'read', 'all']).default('unread')
+    .describe('Filter emails by read status'),
+  maxResults: z.number().int().min(1).max(50).default(20)
+    .describe('Maximum number of emails to return'),
+  dateRange: z.object({
+    after: z.string().optional().describe('Start date (ISO 8601 or YYYY-MM-DD)'),
+    before: z.string().optional().describe('End date (ISO 8601 or YYYY-MM-DD)'),
+  }).optional().describe('Filter by date range'),
+  includeBody: z.boolean().default(false)
+    .describe('Include full email body text (default: metadata + snippet only)'),
+});
+
+function formatEmailList(emails: EmailSummary[], totalCount: number, filter: string): string {
+  if (emails.length === 0) {
+    return `No ${filter === 'all' ? '' : filter + ' '}emails found.`;
+  }
+
+  const header = `Found ${emails.length} ${filter === 'all' ? '' : filter + ' '}emails (${emails.length} of ${totalCount} total):\n`;
+
+  const items = emails.map((email, i) => {
+    const fromStr = email.from.name
+      ? `${email.from.name} <${email.from.address}>`
+      : email.from.address;
+
+    let entry = `${i + 1}. From: ${fromStr}\n   Subject: ${email.subject}\n   Date: ${email.date}\n   Snippet: ${email.snippet}`;
+
+    if (email.hasAttachments && email.attachments) {
+      const attachStr = email.attachments
+        .map(a => `${a.filename} (${formatSize(a.size)})`)
+        .join(', ');
+      entry += `\n   Attachments: ${attachStr}`;
+    }
+
+    if (email.body) {
+      entry = `Email from ${fromStr}\nSubject: ${email.subject}\nDate: ${email.date}\n\nBody:\n${email.body}`;
+      if (email.hasAttachments && email.attachments) {
+        const attachStr = email.attachments
+          .map(a => `${a.filename} (${formatSize(a.size)})`)
+          .join(', ');
+        entry += `\n\nAttachments: ${attachStr}`;
+      }
+    }
+
+    return entry;
+  });
+
+  return header + '\n' + items.join('\n\n');
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export const readEmails: RunnableTool<z.infer<typeof schema>> = {
+  definition: {
+    name: 'read_emails',
+    description:
+      'Read emails from the user\'s Gmail inbox. Use when the user asks to see their emails, check inbox, or read specific messages. Returns email metadata and snippets by default; set includeBody=true for full content.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        filter: {
+          type: 'string',
+          enum: ['unread', 'read', 'all'],
+          description: 'Filter emails by read status. Default: unread.',
+        },
+        maxResults: {
+          type: 'number',
+          description: 'Maximum emails to return (1-50). Default: 20.',
+        },
+        dateRange: {
+          type: 'object',
+          properties: {
+            after: { type: 'string', description: 'Start date (ISO 8601)' },
+            before: { type: 'string', description: 'End date (ISO 8601)' },
+          },
+          description: 'Optional date range filter.',
+        },
+        includeBody: {
+          type: 'boolean',
+          description: 'Include full email body. Default: false.',
+        },
+      },
+    },
+  },
+  schema,
+  timeoutMs: 15000,
+
+  async run({ filter, maxResults, dateRange, includeBody }) {
+    const userId = '00000000-0000-0000-0000-000000000001';
+
+    if (!emailService.isConnected(userId)) {
+      throw new ToolError('Gmail not connected. Visit http://localhost:5001/api/v1/auth/gmail to authorize.');
+    }
+
+    try {
+      log.info({ filter, maxResults, includeBody }, 'Reading emails');
+      const result = await emailService.listEmails(userId, filter, maxResults, dateRange, includeBody);
+      log.info({ returnedCount: result.returnedCount, totalCount: result.totalCount }, 'Emails fetched');
+      return formatEmailList(result.emails, result.totalCount, filter);
+    } catch (err: any) {
+      log.error({ err }, 'Failed to read emails');
+      if (err.message?.includes('Gmail not connected') || err.message?.includes('Gmail authorization')) {
+        throw new ToolError(err.message);
+      }
+      throw new ToolError(`Failed to read emails: ${err.message}`);
+    }
+  },
+};

--- a/backend/src/tools/replyEmail.ts
+++ b/backend/src/tools/replyEmail.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { RunnableTool } from './types';
+import { ToolError } from '../errors';
+import { emailService } from '../services/emailService';
+import logger from '../config/logger';
+
+const log = logger.child({ tool: 'reply_email' });
+
+const schema = z.object({
+  emailId: z.string().min(1).describe('Gmail message ID of the email to reply to'),
+  body: z.string().min(1).describe('Reply body text'),
+});
+
+export const replyEmail: RunnableTool<z.infer<typeof schema>> = {
+  definition: {
+    name: 'reply_email',
+    description:
+      'Create a reply draft to an existing email. Use when the user asks to reply to a specific email. The reply draft is saved to Gmail Drafts in the correct thread — it is NOT sent. The user must open Gmail to review and send.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        emailId: { type: 'string', description: 'Gmail message ID of the email to reply to' },
+        body: { type: 'string', description: 'Reply body text' },
+      },
+      required: ['emailId', 'body'],
+    },
+  },
+  schema,
+  timeoutMs: 10000,
+
+  async run({ emailId, body }) {
+    const userId = '00000000-0000-0000-0000-000000000001';
+
+    if (!emailService.isConnected(userId)) {
+      throw new ToolError('Gmail not connected. Visit http://localhost:5001/api/v1/auth/gmail to authorize.');
+    }
+
+    try {
+      log.info({ emailId }, 'Creating reply draft');
+      const result = await emailService.createReplyDraft(userId, emailId, body);
+      log.info({ draftId: result.draftId, threadId: result.threadId }, 'Reply draft created');
+
+      return [
+        'Reply draft saved to Gmail.',
+        `  Thread: ${result.subject}`,
+        `  To: ${result.to}`,
+        `  Preview: ${result.bodyPreview}`,
+        `  Draft ID: ${result.draftId}`,
+        '',
+        'Open Gmail to review and send.',
+      ].join('\n');
+    } catch (err: any) {
+      log.error({ err }, 'Failed to create reply draft');
+      if (err.message?.includes('Gmail not connected') || err.message?.includes('Gmail authorization')) {
+        throw new ToolError(err.message);
+      }
+      throw new ToolError(`Failed to create reply: ${err.message}`);
+    }
+  },
+};

--- a/backend/src/tools/searchEmails.ts
+++ b/backend/src/tools/searchEmails.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+import { RunnableTool } from './types';
+import { ToolError } from '../errors';
+import { emailService } from '../services/emailService';
+import { EmailSummary } from '../types/email';
+import logger from '../config/logger';
+
+const log = logger.child({ tool: 'search_emails' });
+
+const schema = z.object({
+  from: z.string().optional().describe('Sender email address or name'),
+  to: z.string().optional().describe('Recipient email address'),
+  subject: z.string().optional().describe('Subject line keyword'),
+  keywords: z.string().optional().describe('Search keywords in email body'),
+  dateRange: z.object({
+    after: z.string().optional().describe('Start date (ISO 8601 or YYYY-MM-DD)'),
+    before: z.string().optional().describe('End date (ISO 8601 or YYYY-MM-DD)'),
+  }).optional().describe('Filter by date range'),
+  hasAttachment: z.boolean().optional().describe('Filter for emails with attachments'),
+  maxResults: z.number().int().min(1).max(50).default(20)
+    .describe('Maximum results to return'),
+  includeBody: z.boolean().default(false)
+    .describe('Include full email body text'),
+});
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatSearchResults(emails: EmailSummary[], totalCount: number): string {
+  if (emails.length === 0) {
+    return 'No emails found matching your search.';
+  }
+
+  const header = `Found ${emails.length} matching emails (${emails.length} of ${totalCount} total):\n`;
+
+  const items = emails.map((email, i) => {
+    const fromStr = email.from.name
+      ? `${email.from.name} <${email.from.address}>`
+      : email.from.address;
+
+    let entry = `${i + 1}. From: ${fromStr}\n   Subject: ${email.subject}\n   Date: ${email.date}\n   Snippet: ${email.snippet}`;
+
+    if (email.hasAttachments && email.attachments) {
+      const attachStr = email.attachments
+        .map(a => `${a.filename} (${formatSize(a.size)})`)
+        .join(', ');
+      entry += `\n   Attachments: ${attachStr}`;
+    }
+
+    if (email.body) {
+      entry = `Email from ${fromStr}\nSubject: ${email.subject}\nDate: ${email.date}\n\nBody:\n${email.body}`;
+      if (email.hasAttachments && email.attachments) {
+        const attachStr = email.attachments
+          .map(a => `${a.filename} (${formatSize(a.size)})`)
+          .join(', ');
+        entry += `\n\nAttachments: ${attachStr}`;
+      }
+    }
+
+    return entry;
+  });
+
+  return header + '\n' + items.join('\n\n');
+}
+
+export const searchEmails: RunnableTool<z.infer<typeof schema>> = {
+  definition: {
+    name: 'search_emails',
+    description:
+      'Search emails in the user\'s Gmail. Use when the user asks to find specific emails by sender, subject, keywords, date range, or attachments. Returns matching emails with metadata and snippets.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        from: { type: 'string', description: 'Sender email address or name' },
+        to: { type: 'string', description: 'Recipient email address' },
+        subject: { type: 'string', description: 'Subject line keyword' },
+        keywords: { type: 'string', description: 'Search keywords in email body' },
+        dateRange: {
+          type: 'object',
+          properties: {
+            after: { type: 'string', description: 'Start date (ISO 8601)' },
+            before: { type: 'string', description: 'End date (ISO 8601)' },
+          },
+          description: 'Optional date range filter.',
+        },
+        hasAttachment: { type: 'boolean', description: 'Filter for emails with attachments' },
+        maxResults: { type: 'number', description: 'Maximum results to return (1-50). Default: 20.' },
+        includeBody: { type: 'boolean', description: 'Include full email body. Default: false.' },
+      },
+    },
+  },
+  schema,
+  timeoutMs: 15000,
+
+  async run(input) {
+    const userId = '00000000-0000-0000-0000-000000000001';
+
+    if (!emailService.isConnected(userId)) {
+      throw new ToolError('Gmail not connected. Visit http://localhost:5001/api/v1/auth/gmail to authorize.');
+    }
+
+    try {
+      log.info({ from: input.from, subject: input.subject, keywords: input.keywords }, 'Searching emails');
+      const result = await emailService.searchEmails(userId, input);
+      log.info({ returnedCount: result.returnedCount, totalCount: result.totalCount }, 'Search complete');
+      return formatSearchResults(result.emails, result.totalCount);
+    } catch (err: any) {
+      log.error({ err }, 'Failed to search emails');
+      if (err.message?.includes('Gmail not connected') || err.message?.includes('Gmail authorization')) {
+        throw new ToolError(err.message);
+      }
+      throw new ToolError(`Failed to search emails: ${err.message}`);
+    }
+  },
+};

--- a/backend/src/tools/summarizeEmails.ts
+++ b/backend/src/tools/summarizeEmails.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+import { RunnableTool } from './types';
+import { ToolError } from '../errors';
+import { emailService } from '../services/emailService';
+import logger from '../config/logger';
+
+const log = logger.child({ tool: 'summarize_emails' });
+
+const schema = z.object({
+  filter: z.enum(['unread', 'read', 'all']).default('unread')
+    .describe('Which emails to summarize'),
+  maxResults: z.number().int().min(1).max(50).default(50)
+    .describe('Maximum emails to process for summary'),
+});
+
+export const summarizeEmails: RunnableTool<z.infer<typeof schema>> = {
+  definition: {
+    name: 'summarize_emails',
+    description:
+      'Fetch emails for summarization. Use when the user asks to summarize their inbox, get an overview of recent emails, or categorize their messages. Returns raw email metadata for the AI to categorize and summarize.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        filter: {
+          type: 'string',
+          enum: ['unread', 'read', 'all'],
+          description: 'Which emails to summarize. Default: unread.',
+        },
+        maxResults: {
+          type: 'number',
+          description: 'Maximum emails to process (1-50). Default: 50.',
+        },
+      },
+    },
+  },
+  schema,
+  timeoutMs: 30000,
+
+  async run({ filter, maxResults }) {
+    const userId = '00000000-0000-0000-0000-000000000001';
+
+    if (!emailService.isConnected(userId)) {
+      throw new ToolError('Gmail not connected. Visit http://localhost:5001/api/v1/auth/gmail to authorize.');
+    }
+
+    try {
+      log.info({ filter, maxResults }, 'Fetching emails for summarization');
+      const result = await emailService.listEmails(userId, filter, maxResults);
+
+      if (result.emails.length === 0) {
+        return `No ${filter === 'all' ? '' : filter + ' '}emails found to summarize.`;
+      }
+
+      const items = result.emails.map((email, i) => {
+        const fromStr = email.from.name
+          ? `${email.from.name} <${email.from.address}>`
+          : email.from.address;
+        let entry = `${i + 1}. From: ${fromStr} | Subject: ${email.subject} | Date: ${email.date}`;
+        entry += `\n   Snippet: ${email.snippet}`;
+        if (email.labels && email.labels.length > 0) {
+          entry += `\n   Labels: ${email.labels.join(', ')}`;
+        }
+        return entry;
+      });
+
+      log.info({ emailCount: result.emails.length }, 'Emails fetched for summarization');
+      return `Fetched ${result.emails.length} emails for summarization:\n\n${items.join('\n\n')}`;
+    } catch (err: any) {
+      log.error({ err }, 'Failed to fetch emails for summarization');
+      if (err.message?.includes('Gmail not connected') || err.message?.includes('Gmail authorization')) {
+        throw new ToolError(err.message);
+      }
+      throw new ToolError(`Failed to summarize emails: ${err.message}`);
+    }
+  },
+};

--- a/backend/src/types/email.ts
+++ b/backend/src/types/email.ts
@@ -1,0 +1,63 @@
+export interface GmailTokenStore {
+  [userId: string]: GmailTokenEntry;
+}
+
+export interface GmailTokenEntry {
+  accessToken: string;
+  refreshToken: string;
+  expiryDate: number;
+  scopes: string[];
+  email: string;
+  obtainedAt: string;
+}
+
+export interface EmailSummary {
+  id: string;
+  threadId: string;
+  from: {
+    name: string;
+    address: string;
+  };
+  to: string[];
+  subject: string;
+  date: string;
+  snippet: string;
+  isUnread: boolean;
+  hasAttachments: boolean;
+  attachments?: AttachmentMeta[];
+  labels?: string[];
+  body?: string;
+}
+
+export interface AttachmentMeta {
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
+export interface EmailDraft {
+  to: string;
+  subject: string;
+  body: string;
+  cc?: string;
+  bcc?: string;
+}
+
+export interface ReplyDraft {
+  emailId: string;
+  body: string;
+}
+
+export interface DraftResult {
+  draftId: string;
+  threadId: string;
+  to: string;
+  subject: string;
+  bodyPreview: string;
+}
+
+export interface EmailListResult {
+  emails: EmailSummary[];
+  totalCount: number;
+  returnedCount: number;
+}

--- a/backend/tests/routes/gmailAuth.test.ts
+++ b/backend/tests/routes/gmailAuth.test.ts
@@ -1,0 +1,139 @@
+const mockOAuth2Instance = {
+  generateAuthUrl: jest.fn(),
+  getToken: jest.fn(),
+  setCredentials: jest.fn(),
+};
+
+const mockGmailUsers = {
+  getProfile: jest.fn(),
+};
+
+jest.mock('googleapis', () => ({
+  google: {
+    auth: {
+      OAuth2: jest.fn(() => mockOAuth2Instance),
+    },
+    gmail: jest.fn(() => ({
+      users: mockGmailUsers,
+    })),
+  },
+}));
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { emailService } from '../../src/services/emailService';
+import fs from 'fs';
+import path from 'path';
+
+const TOKEN_FILE = path.join(__dirname, '../../.gmail-tokens.json');
+
+function cleanupTokenFile() {
+  try {
+    if (fs.existsSync(TOKEN_FILE)) fs.unlinkSync(TOKEN_FILE);
+  } catch { /* ignore */ }
+}
+
+describe('Gmail Auth Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupTokenFile();
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  afterAll(() => {
+    cleanupTokenFile();
+  });
+
+  describe('GET /api/v1/auth/gmail', () => {
+    it('redirects to Google consent URL', async () => {
+      mockOAuth2Instance.generateAuthUrl.mockReturnValue('https://accounts.google.com/o/oauth2/v2/auth?test=1');
+
+      const res = await request(app).get('/api/v1/auth/gmail');
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toContain('accounts.google.com');
+    });
+  });
+
+  describe('GET /api/v1/auth/gmail/callback', () => {
+    it('exchanges code for tokens and returns HTML confirmation', async () => {
+      mockOAuth2Instance.getToken.mockResolvedValue({
+        tokens: {
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expiry_date: Date.now() + 3600_000,
+          scope: 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose',
+        },
+      });
+      mockGmailUsers.getProfile.mockResolvedValue({
+        data: { emailAddress: 'user@gmail.com' },
+      });
+
+      const res = await request(app)
+        .get('/api/v1/auth/gmail/callback')
+        .query({ code: 'auth-code-123', state: 'user-id-1' });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('Gmail Connected');
+      expect(emailService.isConnected('user-id-1')).toBe(true);
+    });
+
+    it('returns 400 when user denied access', async () => {
+      const res = await request(app)
+        .get('/api/v1/auth/gmail/callback')
+        .query({ error: 'access_denied', state: 'user-id-1' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.message).toBe('Authorization denied by user.');
+    });
+
+    it('returns 400 when code is missing', async () => {
+      const res = await request(app)
+        .get('/api/v1/auth/gmail/callback')
+        .query({ state: 'user-id-1' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.message).toBe('Missing authorization code.');
+    });
+
+    it('returns 500 when token exchange fails', async () => {
+      mockOAuth2Instance.getToken.mockRejectedValue(new Error('Exchange failed'));
+
+      const res = await request(app)
+        .get('/api/v1/auth/gmail/callback')
+        .query({ code: 'bad-code', state: 'user-id-1' });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error.message).toBe('Token exchange failed.');
+    });
+  });
+
+  describe('GET /api/v1/auth/gmail/status', () => {
+    it('returns connected: false when no tokens', async () => {
+      const res = await request(app).get('/api/v1/auth/gmail/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.connected).toBe(false);
+      expect(res.body.authorizeUrl).toBe('/api/v1/auth/gmail');
+    });
+
+    it('returns connected: true with email and scopes', async () => {
+      const userId = '00000000-0000-0000-0000-000000000001';
+      emailService.saveTokens(userId, {
+        accessToken: 'token',
+        refreshToken: 'refresh',
+        expiryDate: Date.now() + 3600_000,
+        scopes: ['gmail.readonly', 'gmail.compose'],
+        email: 'user@gmail.com',
+        obtainedAt: '2026-07-12T10:00:00Z',
+      });
+
+      const res = await request(app).get('/api/v1/auth/gmail/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.connected).toBe(true);
+      expect(res.body.email).toBe('user@gmail.com');
+      expect(res.body.scopes).toEqual(['gmail.readonly', 'gmail.compose']);
+    });
+  });
+});

--- a/backend/tests/services/emailService.test.ts
+++ b/backend/tests/services/emailService.test.ts
@@ -1,0 +1,398 @@
+import fs from 'fs';
+import path from 'path';
+
+const TOKEN_FILE = path.join(__dirname, '../../.gmail-tokens.json');
+
+const mockOAuth2Instance = {
+  setCredentials: jest.fn(),
+  refreshAccessToken: jest.fn(),
+  generateAuthUrl: jest.fn(),
+  getToken: jest.fn(),
+};
+
+const mockGmailMessages = {
+  list: jest.fn(),
+  get: jest.fn(),
+};
+
+const mockGmailDrafts = {
+  create: jest.fn(),
+};
+
+jest.mock('googleapis', () => ({
+  google: {
+    auth: {
+      OAuth2: jest.fn(() => mockOAuth2Instance),
+    },
+    gmail: jest.fn(() => ({
+      users: {
+        messages: mockGmailMessages,
+        drafts: mockGmailDrafts,
+      },
+    })),
+  },
+}));
+
+import { emailService } from '../../src/services/emailService';
+import { GmailTokenEntry } from '../../src/types/email';
+
+const TEST_USER_ID = 'test-user-001';
+
+function makeTokenEntry(overrides: Partial<GmailTokenEntry> = {}): GmailTokenEntry {
+  return {
+    accessToken: 'access-token-123',
+    refreshToken: 'refresh-token-456',
+    expiryDate: Date.now() + 3600_000,
+    scopes: ['gmail.readonly', 'gmail.compose'],
+    email: 'test@gmail.com',
+    obtainedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function cleanupTokenFile() {
+  try {
+    if (fs.existsSync(TOKEN_FILE)) fs.unlinkSync(TOKEN_FILE);
+  } catch { /* ignore */ }
+}
+
+describe('EmailService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupTokenFile();
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  afterAll(() => {
+    cleanupTokenFile();
+  });
+
+  // ─── Token CRUD ───
+
+  describe('token CRUD', () => {
+    it('returns null for non-existent user', () => {
+      expect(emailService.getTokens('nonexistent')).toBeNull();
+    });
+
+    it('saves and retrieves tokens', () => {
+      const entry = makeTokenEntry();
+      emailService.saveTokens(TEST_USER_ID, entry);
+      const retrieved = emailService.getTokens(TEST_USER_ID);
+      expect(retrieved).toEqual(entry);
+    });
+
+    it('isConnected returns true after saving tokens', () => {
+      emailService.saveTokens(TEST_USER_ID, makeTokenEntry());
+      expect(emailService.isConnected(TEST_USER_ID)).toBe(true);
+    });
+
+    it('isConnected returns false for unknown user', () => {
+      expect(emailService.isConnected('unknown')).toBe(false);
+    });
+
+    it('removes tokens', () => {
+      emailService.saveTokens(TEST_USER_ID, makeTokenEntry());
+      emailService.removeTokens(TEST_USER_ID);
+      expect(emailService.getTokens(TEST_USER_ID)).toBeNull();
+      expect(emailService.isConnected(TEST_USER_ID)).toBe(false);
+    });
+
+    it('handles multiple users independently', () => {
+      const entry1 = makeTokenEntry({ email: 'user1@gmail.com' });
+      const entry2 = makeTokenEntry({ email: 'user2@gmail.com' });
+      emailService.saveTokens('user-1', entry1);
+      emailService.saveTokens('user-2', entry2);
+      expect(emailService.getTokens('user-1')?.email).toBe('user1@gmail.com');
+      expect(emailService.getTokens('user-2')?.email).toBe('user2@gmail.com');
+    });
+  });
+
+  // ─── Auth Client ───
+
+  describe('getAuthClient', () => {
+    it('throws when user has no tokens', async () => {
+      await expect(emailService.getAuthClient('no-tokens-user'))
+        .rejects.toThrow('Gmail not connected');
+    });
+
+    it('returns OAuth2 client with valid tokens', async () => {
+      emailService.saveTokens(TEST_USER_ID, makeTokenEntry());
+      const client = await emailService.getAuthClient(TEST_USER_ID);
+      expect(client).toBe(mockOAuth2Instance);
+      expect(mockOAuth2Instance.setCredentials).toHaveBeenCalled();
+    });
+
+    it('refreshes expired token', async () => {
+      const expired = makeTokenEntry({ expiryDate: Date.now() - 1000 });
+      emailService.saveTokens(TEST_USER_ID, expired);
+
+      mockOAuth2Instance.refreshAccessToken.mockResolvedValue({
+        credentials: {
+          access_token: 'new-access-token',
+          expiry_date: Date.now() + 3600_000,
+        },
+      });
+
+      await emailService.getAuthClient(TEST_USER_ID);
+
+      expect(mockOAuth2Instance.refreshAccessToken).toHaveBeenCalled();
+      const updated = emailService.getTokens(TEST_USER_ID);
+      expect(updated?.accessToken).toBe('new-access-token');
+    });
+
+    it('removes tokens and throws on refresh failure', async () => {
+      const expired = makeTokenEntry({ expiryDate: Date.now() - 1000 });
+      emailService.saveTokens(TEST_USER_ID, expired);
+
+      mockOAuth2Instance.refreshAccessToken.mockRejectedValue(new Error('Token revoked'));
+
+      await expect(emailService.getAuthClient(TEST_USER_ID))
+        .rejects.toThrow('Gmail authorization expired');
+      expect(emailService.isConnected(TEST_USER_ID)).toBe(false);
+    });
+  });
+
+  // ─── Email Parsing ───
+
+  describe('parseEmail', () => {
+    it('parses email with name and address in From header', () => {
+      const msg = {
+        id: 'msg-1',
+        threadId: 'thread-1',
+        snippet: 'Hello there...',
+        labelIds: ['UNREAD', 'INBOX'],
+        payload: {
+          headers: [
+            { name: 'From', value: 'John Doe <john@example.com>' },
+            { name: 'To', value: 'me@example.com' },
+            { name: 'Subject', value: 'Test Subject' },
+            { name: 'Date', value: 'Thu, 12 Jul 2026 10:00:00 +0000' },
+          ],
+          parts: [],
+        },
+      };
+
+      const result = emailService.parseEmail(msg);
+      expect(result.id).toBe('msg-1');
+      expect(result.threadId).toBe('thread-1');
+      expect(result.from).toEqual({ name: 'John Doe', address: 'john@example.com' });
+      expect(result.subject).toBe('Test Subject');
+      expect(result.isUnread).toBe(true);
+      expect(result.snippet).toBe('Hello there...');
+    });
+
+    it('parses email with address-only From header', () => {
+      const msg = {
+        id: 'msg-2',
+        threadId: 'thread-2',
+        snippet: '',
+        labelIds: [],
+        payload: {
+          headers: [{ name: 'From', value: 'plain@example.com' }],
+        },
+      };
+      const result = emailService.parseEmail(msg);
+      expect(result.from).toEqual({ name: '', address: 'plain@example.com' });
+      expect(result.isUnread).toBe(false);
+    });
+  });
+
+  // ─── Body Extraction ───
+
+  describe('extractBody', () => {
+    it('extracts text/plain body', () => {
+      const payload = {
+        mimeType: 'text/plain',
+        body: { data: Buffer.from('Hello world').toString('base64url') },
+      };
+      expect(emailService.extractBody(payload)).toBe('Hello world');
+    });
+
+    it('extracts from multipart preferring text/plain', () => {
+      const payload = {
+        mimeType: 'multipart/alternative',
+        parts: [
+          {
+            mimeType: 'text/plain',
+            body: { data: Buffer.from('Plain text').toString('base64url') },
+          },
+          {
+            mimeType: 'text/html',
+            body: { data: Buffer.from('<p>HTML text</p>').toString('base64url') },
+          },
+        ],
+      };
+      expect(emailService.extractBody(payload)).toBe('Plain text');
+    });
+
+    it('falls back to html-to-text conversion', () => {
+      const payload = {
+        mimeType: 'multipart/alternative',
+        parts: [
+          {
+            mimeType: 'text/html',
+            body: { data: Buffer.from('<p>HTML only</p>').toString('base64url') },
+          },
+        ],
+      };
+      const result = emailService.extractBody(payload);
+      expect(result).toContain('HTML only');
+    });
+
+    it('returns empty string for empty payload', () => {
+      expect(emailService.extractBody(undefined)).toBe('');
+    });
+  });
+
+  // ─── Truncation ───
+
+  describe('truncateBody', () => {
+    it('does not truncate short text', () => {
+      expect(emailService.truncateBody('short text')).toBe('short text');
+    });
+
+    it('truncates and adds marker at limit', () => {
+      const longText = 'A'.repeat(60_000);
+      const result = emailService.truncateBody(longText);
+      expect(result.endsWith('[truncated]')).toBe(true);
+      expect(Buffer.from(result, 'utf-8').length).toBeLessThanOrEqual(50 * 1024 + 20);
+    });
+  });
+
+  // ─── List Emails ───
+
+  describe('listEmails', () => {
+    beforeEach(() => {
+      emailService.saveTokens(TEST_USER_ID, makeTokenEntry());
+    });
+
+    it('lists unread emails', async () => {
+      mockGmailMessages.list.mockResolvedValue({
+        data: {
+          messages: [{ id: 'msg-1' }],
+          resultSizeEstimate: 1,
+        },
+      });
+      mockGmailMessages.get.mockResolvedValue({
+        data: {
+          id: 'msg-1',
+          threadId: 'thread-1',
+          snippet: 'Test snippet',
+          labelIds: ['UNREAD'],
+          payload: {
+            headers: [
+              { name: 'From', value: 'sender@test.com' },
+              { name: 'Subject', value: 'Test' },
+              { name: 'Date', value: '2026-07-12' },
+            ],
+          },
+        },
+      });
+
+      const result = await emailService.listEmails(TEST_USER_ID, 'unread', 10);
+      expect(result.emails).toHaveLength(1);
+      expect(result.emails[0].subject).toBe('Test');
+      expect(result.emails[0].body).toBeUndefined();
+    });
+
+    it('returns empty result for no messages', async () => {
+      mockGmailMessages.list.mockResolvedValue({
+        data: { messages: [], resultSizeEstimate: 0 },
+      });
+
+      const result = await emailService.listEmails(TEST_USER_ID);
+      expect(result.emails).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+    });
+  });
+
+  // ─── Search Emails ───
+
+  describe('searchEmails', () => {
+    beforeEach(() => {
+      emailService.saveTokens(TEST_USER_ID, makeTokenEntry());
+    });
+
+    it('constructs query from search params', async () => {
+      mockGmailMessages.list.mockResolvedValue({ data: { messages: [], resultSizeEstimate: 0 } });
+
+      await emailService.searchEmails(TEST_USER_ID, {
+        from: 'john@test.com',
+        subject: 'report',
+        hasAttachment: true,
+      });
+
+      const call = mockGmailMessages.list.mock.calls[0][0];
+      expect(call.q).toContain('from:john@test.com');
+      expect(call.q).toContain('subject:report');
+      expect(call.q).toContain('has:attachment');
+    });
+  });
+
+  // ─── Create Draft ───
+
+  describe('createDraft', () => {
+    beforeEach(() => {
+      emailService.saveTokens(TEST_USER_ID, makeTokenEntry());
+    });
+
+    it('creates a draft and returns result', async () => {
+      mockGmailDrafts.create.mockResolvedValue({
+        data: {
+          id: 'draft-1',
+          message: { threadId: 'thread-1' },
+        },
+      });
+
+      const result = await emailService.createDraft(TEST_USER_ID, {
+        to: 'recipient@test.com',
+        subject: 'Test Draft',
+        body: 'Hello from the test',
+      });
+
+      expect(result.draftId).toBe('draft-1');
+      expect(result.to).toBe('recipient@test.com');
+      expect(result.subject).toBe('Test Draft');
+    });
+  });
+
+  // ─── Create Reply Draft ───
+
+  describe('createReplyDraft', () => {
+    beforeEach(() => {
+      emailService.saveTokens(TEST_USER_ID, makeTokenEntry());
+    });
+
+    it('creates a reply draft with threading headers', async () => {
+      mockGmailMessages.get.mockResolvedValue({
+        data: {
+          id: 'original-msg',
+          threadId: 'thread-1',
+          payload: {
+            headers: [
+              { name: 'From', value: 'Original Sender <sender@test.com>' },
+              { name: 'Subject', value: 'Original Subject' },
+              { name: 'Message-ID', value: '<msg-id@test.com>' },
+              { name: 'References', value: '<prev-msg@test.com>' },
+            ],
+          },
+        },
+      });
+
+      mockGmailDrafts.create.mockResolvedValue({
+        data: { id: 'reply-draft-1', message: { threadId: 'thread-1' } },
+      });
+
+      const result = await emailService.createReplyDraft(TEST_USER_ID, 'original-msg', 'Thanks!');
+
+      expect(result.draftId).toBe('reply-draft-1');
+      expect(result.threadId).toBe('thread-1');
+      expect(result.to).toBe('sender@test.com');
+      expect(result.subject).toBe('Re: Original Subject');
+
+      const createCall = mockGmailDrafts.create.mock.calls[0][0];
+      expect(createCall.requestBody.message.threadId).toBe('thread-1');
+    });
+  });
+});

--- a/backend/tests/tools/draftEmail.test.ts
+++ b/backend/tests/tools/draftEmail.test.ts
@@ -1,0 +1,140 @@
+jest.mock('googleapis', () => ({
+  google: {
+    auth: { OAuth2: jest.fn(() => ({ setCredentials: jest.fn(), refreshAccessToken: jest.fn() })) },
+    gmail: jest.fn(() => ({
+      users: {
+        messages: { list: jest.fn(), get: jest.fn() },
+        drafts: { create: jest.fn() },
+      },
+    })),
+  },
+}));
+
+import fs from 'fs';
+import path from 'path';
+import { summarizeEmails } from '../../src/tools/summarizeEmails';
+import { draftEmail } from '../../src/tools/draftEmail';
+import { replyEmail } from '../../src/tools/replyEmail';
+
+const TOKEN_FILE = path.join(__dirname, '../../.gmail-tokens.json');
+
+function cleanupTokenFile() {
+  try { if (fs.existsSync(TOKEN_FILE)) fs.unlinkSync(TOKEN_FILE); } catch { /* ignore */ }
+}
+
+describe('summarize_emails tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupTokenFile();
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  afterAll(() => cleanupTokenFile());
+
+  it('has correct definition', () => {
+    expect(summarizeEmails.definition.name).toBe('summarize_emails');
+    expect(summarizeEmails.timeoutMs).toBe(30000);
+  });
+
+  it('validates schema defaults', () => {
+    const result = summarizeEmails.schema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.filter).toBe('unread');
+      expect(result.data.maxResults).toBe(50);
+    }
+  });
+
+  it('throws when Gmail not connected', async () => {
+    await expect(summarizeEmails.run({ filter: 'unread', maxResults: 50 }))
+      .rejects.toThrow('Gmail not connected');
+  });
+});
+
+describe('draft_email tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupTokenFile();
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  afterAll(() => cleanupTokenFile());
+
+  it('has correct definition', () => {
+    expect(draftEmail.definition.name).toBe('draft_email');
+    expect(draftEmail.timeoutMs).toBe(10000);
+  });
+
+  it('validates required fields', () => {
+    const result = draftEmail.schema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('validates email format for "to" field', () => {
+    const result = draftEmail.schema.safeParse({
+      to: 'not-an-email',
+      subject: 'Test',
+      body: 'Test body',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid draft input', () => {
+    const result = draftEmail.schema.safeParse({
+      to: 'valid@example.com',
+      subject: 'Test Subject',
+      body: 'Hello there',
+      cc: 'cc@example.com',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('throws when Gmail not connected', async () => {
+    await expect(draftEmail.run({
+      to: 'test@example.com',
+      subject: 'Test',
+      body: 'Hello',
+    })).rejects.toThrow('Gmail not connected');
+  });
+});
+
+describe('reply_email tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupTokenFile();
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  afterAll(() => cleanupTokenFile());
+
+  it('has correct definition', () => {
+    expect(replyEmail.definition.name).toBe('reply_email');
+    expect(replyEmail.timeoutMs).toBe(10000);
+  });
+
+  it('validates required fields', () => {
+    const result = replyEmail.schema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty emailId', () => {
+    const result = replyEmail.schema.safeParse({ emailId: '', body: 'Reply text' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid reply input', () => {
+    const result = replyEmail.schema.safeParse({
+      emailId: 'msg-123',
+      body: 'Thanks for your message!',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('throws when Gmail not connected', async () => {
+    await expect(replyEmail.run({ emailId: 'msg-123', body: 'Reply' }))
+      .rejects.toThrow('Gmail not connected');
+  });
+});

--- a/backend/tests/tools/readEmails.test.ts
+++ b/backend/tests/tools/readEmails.test.ts
@@ -1,0 +1,93 @@
+jest.mock('googleapis', () => ({
+  google: {
+    auth: { OAuth2: jest.fn(() => ({ setCredentials: jest.fn(), refreshAccessToken: jest.fn() })) },
+    gmail: jest.fn(() => ({
+      users: {
+        messages: { list: jest.fn(), get: jest.fn() },
+        drafts: { create: jest.fn() },
+      },
+    })),
+  },
+}));
+
+import fs from 'fs';
+import path from 'path';
+import { readEmails } from '../../src/tools/readEmails';
+import { searchEmails } from '../../src/tools/searchEmails';
+import { emailService } from '../../src/services/emailService';
+
+const TOKEN_FILE = path.join(__dirname, '../../.gmail-tokens.json');
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+function cleanupTokenFile() {
+  try { if (fs.existsSync(TOKEN_FILE)) fs.unlinkSync(TOKEN_FILE); } catch { /* ignore */ }
+}
+
+describe('read_emails tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupTokenFile();
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  afterAll(() => cleanupTokenFile());
+
+  it('has correct definition', () => {
+    expect(readEmails.definition.name).toBe('read_emails');
+    expect(readEmails.timeoutMs).toBe(15000);
+  });
+
+  it('validates schema with defaults', () => {
+    const result = readEmails.schema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.filter).toBe('unread');
+      expect(result.data.maxResults).toBe(20);
+      expect(result.data.includeBody).toBe(false);
+    }
+  });
+
+  it('rejects invalid maxResults', () => {
+    const result = readEmails.schema.safeParse({ maxResults: 100 });
+    expect(result.success).toBe(false);
+  });
+
+  it('throws when Gmail not connected', async () => {
+    await expect(readEmails.run({ filter: 'unread', maxResults: 10, includeBody: false }))
+      .rejects.toThrow('Gmail not connected');
+  });
+});
+
+describe('search_emails tool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupTokenFile();
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  afterAll(() => cleanupTokenFile());
+
+  it('has correct definition', () => {
+    expect(searchEmails.definition.name).toBe('search_emails');
+    expect(searchEmails.timeoutMs).toBe(15000);
+  });
+
+  it('validates schema with defaults', () => {
+    const result = searchEmails.schema.safeParse({ from: 'test@example.com' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxResults).toBe(20);
+      expect(result.data.includeBody).toBe(false);
+    }
+  });
+
+  it('throws when Gmail not connected', async () => {
+    await expect(searchEmails.run({
+      maxResults: 10,
+      includeBody: false,
+      from: 'test@example.com',
+    })).rejects.toThrow('Gmail not connected');
+  });
+});

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -539,7 +539,7 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^29.6.3":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -2842,7 +2842,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@^29.7.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==

--- a/docs/postman/chat-thread-api.postman_collection.json
+++ b/docs/postman/chat-thread-api.postman_collection.json
@@ -453,6 +453,76 @@
       ]
     },
     {
+      "name": "Gmail OAuth",
+      "item": [
+        {
+          "name": "Initiate Gmail OAuth",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 302 redirect', () => pm.response.to.have.status(302));",
+                  "pm.test('Redirects to Google', () => {",
+                  "  pm.expect(pm.response.headers.get('Location')).to.include('accounts.google.com');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/auth/gmail",
+              "host": ["{{base_url}}"],
+              "path": ["api", "v1", "auth", "gmail"]
+            }
+          }
+        },
+        {
+          "name": "Gmail OAuth Callback (simulated)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/auth/gmail/callback?code=TEST_CODE&state=TEST_USER_ID",
+              "host": ["{{base_url}}"],
+              "path": ["api", "v1", "auth", "gmail", "callback"],
+              "query": [
+                { "key": "code", "value": "TEST_CODE" },
+                { "key": "state", "value": "TEST_USER_ID" }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Gmail Connection Status",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Has connected field', () => {",
+                  "  pm.expect(pm.response.json()).to.have.property('connected');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/auth/gmail/status",
+              "host": ["{{base_url}}"],
+              "path": ["api", "v1", "auth", "gmail", "status"]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "Legacy Endpoints",
       "item": [
         {

--- a/specs/003-gmail-agent/contracts/oauth-endpoints.md
+++ b/specs/003-gmail-agent/contracts/oauth-endpoints.md
@@ -1,0 +1,92 @@
+# Contract: Gmail OAuth2 Endpoints
+
+## GET /api/v1/auth/gmail
+
+Initiates the Gmail OAuth2 authorization flow. Redirects the user to Google's consent screen.
+
+**Auth**: Requires `authMiddleware` (uses `req.user.id` for token keying).
+
+**Response**: HTTP 302 redirect to Google OAuth2 consent URL.
+
+**Query Parameters**: None.
+
+**Redirect URL pattern**:
+```
+https://accounts.google.com/o/oauth2/v2/auth?
+  client_id={GOOGLE_CLIENT_ID}&
+  redirect_uri=http://localhost:5001/api/v1/auth/gmail/callback&
+  response_type=code&
+  scope=https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose&
+  access_type=offline&
+  prompt=consent&
+  state={userId}
+```
+
+**Error responses**:
+
+| Status | Body | When |
+|--------|------|------|
+| 500 | `{"error": {"type": "internal_error", "message": "Google OAuth not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET."}}` | Missing env vars |
+
+---
+
+## GET /api/v1/auth/gmail/callback
+
+Handles the OAuth2 callback from Google. Exchanges authorization code for tokens and stores them.
+
+**Auth**: None (callback from Google, `state` param carries user ID).
+
+**Query Parameters**:
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `code` | string | Yes | Authorization code from Google |
+| `state` | string | Yes | User ID passed through OAuth flow |
+| `error` | string | No | Error code if user denied access |
+
+**Success response**: HTTP 200 with HTML page confirming authorization.
+
+```html
+<html>
+<body>
+  <h1>Gmail Connected</h1>
+  <p>You can close this window and return to the chat.</p>
+</body>
+</html>
+```
+
+**Error responses**:
+
+| Status | Body | When |
+|--------|------|------|
+| 400 | `{"error": {"type": "bad_request", "message": "Authorization denied by user."}}` | User clicked "Deny" |
+| 400 | `{"error": {"type": "bad_request", "message": "Missing authorization code."}}` | No `code` param |
+| 500 | `{"error": {"type": "internal_error", "message": "Token exchange failed."}}` | Google API error |
+
+---
+
+## GET /api/v1/auth/gmail/status
+
+Returns the current Gmail connection status for the authenticated user.
+
+**Auth**: Requires `authMiddleware`.
+
+**Success response** (connected):
+
+```json
+{
+  "connected": true,
+  "email": "user@gmail.com",
+  "scopes": ["gmail.readonly", "gmail.compose"],
+  "connectedAt": "2026-07-12T10:00:00Z"
+}
+```
+
+**Success response** (not connected):
+
+```json
+{
+  "connected": false,
+  "authorizeUrl": "/api/v1/auth/gmail"
+}
+```

--- a/specs/003-gmail-agent/contracts/tool-schemas.md
+++ b/specs/003-gmail-agent/contracts/tool-schemas.md
@@ -1,0 +1,226 @@
+# Contract: Gmail Tool Schemas
+
+All tools follow the `RunnableTool` interface defined in `backend/src/tools/types.ts`.
+
+---
+
+## read_emails
+
+**File**: `backend/src/tools/readEmails.ts`
+**Timeout**: 15,000ms
+
+**Input schema** (Zod + JSON Schema):
+
+```typescript
+z.object({
+  filter: z.enum(['unread', 'read', 'all']).default('unread')
+    .describe('Filter emails by read status'),
+  maxResults: z.number().int().min(1).max(50).default(20)
+    .describe('Maximum number of emails to return'),
+  dateRange: z.object({
+    after: z.string().optional().describe('Start date (ISO 8601 or YYYY-MM-DD)'),
+    before: z.string().optional().describe('End date (ISO 8601 or YYYY-MM-DD)'),
+  }).optional().describe('Filter by date range'),
+  includeBody: z.boolean().default(false)
+    .describe('Include full email body text (default: metadata + snippet only)'),
+})
+```
+
+**JSON Schema** (for tool definition):
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filter": {
+      "type": "string",
+      "enum": ["unread", "read", "all"],
+      "description": "Filter emails by read status. Default: unread."
+    },
+    "maxResults": {
+      "type": "number",
+      "description": "Maximum emails to return (1-50). Default: 20."
+    },
+    "dateRange": {
+      "type": "object",
+      "properties": {
+        "after": { "type": "string", "description": "Start date (ISO 8601)" },
+        "before": { "type": "string", "description": "End date (ISO 8601)" }
+      },
+      "description": "Optional date range filter."
+    },
+    "includeBody": {
+      "type": "boolean",
+      "description": "Include full email body. Default: false."
+    }
+  }
+}
+```
+
+**Output format** (string):
+
+```
+Found 5 unread emails (5 of 12 total):
+
+1. From: John Doe <john@example.com>
+   Subject: Q3 Report Review
+   Date: 2026-07-12 10:30 AM
+   Snippet: Please review the attached Q3 report by Friday...
+   Attachments: report.pdf (2.1 MB)
+
+2. From: ...
+```
+
+When `includeBody: true`:
+```
+Email from John Doe <john@example.com>
+Subject: Q3 Report Review
+Date: 2026-07-12 10:30 AM
+
+Body:
+Hi team,
+
+Please review the attached Q3 report by Friday...
+[truncated at 50KB]
+
+Attachments: report.pdf (2.1 MB)
+```
+
+---
+
+## search_emails
+
+**File**: `backend/src/tools/searchEmails.ts`
+**Timeout**: 15,000ms
+
+**Input schema**:
+
+```typescript
+z.object({
+  from: z.string().optional().describe('Sender email address or name'),
+  to: z.string().optional().describe('Recipient email address'),
+  subject: z.string().optional().describe('Subject line keyword'),
+  keywords: z.string().optional().describe('Search keywords in email body'),
+  dateRange: z.object({
+    after: z.string().optional().describe('Start date (ISO 8601 or YYYY-MM-DD)'),
+    before: z.string().optional().describe('End date (ISO 8601 or YYYY-MM-DD)'),
+  }).optional().describe('Filter by date range'),
+  hasAttachment: z.boolean().optional().describe('Filter for emails with attachments'),
+  maxResults: z.number().int().min(1).max(50).default(20)
+    .describe('Maximum results to return'),
+  includeBody: z.boolean().default(false)
+    .describe('Include full email body text'),
+})
+```
+
+**Query construction**: The tool constructs Gmail search queries from parameters:
+- `from` → `from:value`
+- `to` → `to:value`
+- `subject` → `subject:value`
+- `keywords` → raw search terms
+- `dateRange.after` → `after:YYYY/MM/DD`
+- `dateRange.before` → `before:YYYY/MM/DD`
+- `hasAttachment` → `has:attachment`
+
+**Output format**: Same as `read_emails`.
+
+---
+
+## summarize_emails
+
+**File**: `backend/src/tools/summarizeEmails.ts`
+**Timeout**: 30,000ms
+
+**Input schema**:
+
+```typescript
+z.object({
+  filter: z.enum(['unread', 'read', 'all']).default('unread')
+    .describe('Which emails to summarize'),
+  maxResults: z.number().int().min(1).max(50).default(50)
+    .describe('Maximum emails to process for summary'),
+})
+```
+
+**Output format** (string — raw data for LLM to categorize):
+
+```
+Fetched 30 emails for summarization:
+
+1. From: boss@company.com | Subject: Action Required: Budget Approval | Date: 2026-07-12
+   Snippet: Please approve the Q3 budget by EOD...
+   Labels: IMPORTANT, UNREAD
+
+2. From: newsletter@tech.com | Subject: Weekly Tech Digest | Date: 2026-07-12
+   Snippet: This week in tech: AI advances...
+   Labels: CATEGORY_PROMOTIONS, UNREAD
+
+...
+```
+
+The LLM receives this raw list and produces the categorized summary in its response.
+
+---
+
+## draft_email
+
+**File**: `backend/src/tools/draftEmail.ts`
+**Timeout**: 10,000ms
+
+**Input schema**:
+
+```typescript
+z.object({
+  to: z.string().email().describe('Recipient email address'),
+  subject: z.string().min(1).describe('Email subject line'),
+  body: z.string().min(1).describe('Email body text'),
+  cc: z.string().optional().describe('CC email addresses (comma-separated)'),
+  bcc: z.string().optional().describe('BCC email addresses (comma-separated)'),
+})
+```
+
+**Output format**:
+
+```
+Draft saved to Gmail.
+  To: john@example.com
+  Subject: Meeting Rescheduled to Friday
+  Preview: Hi John, I wanted to let you know that our meeting has been rescheduled to Friday at 2 PM...
+  Draft ID: r1234567890
+
+Open Gmail to review and send.
+```
+
+---
+
+## reply_email
+
+**File**: `backend/src/tools/replyEmail.ts`
+**Timeout**: 10,000ms
+
+**Input schema**:
+
+```typescript
+z.object({
+  emailId: z.string().min(1).describe('Gmail message ID of the email to reply to'),
+  body: z.string().min(1).describe('Reply body text'),
+})
+```
+
+**Output format**:
+
+```
+Reply draft saved to Gmail.
+  Thread: Re: Q3 Report Review
+  To: john@example.com
+  Preview: Thanks for the report, John. I've reviewed it and have a few suggestions...
+  Draft ID: r9876543210
+
+Open Gmail to review and send.
+```
+
+**Threading**: The tool fetches the original email to extract `Message-ID`, `References`, and `threadId`. The draft is created with:
+- `threadId`: original email's threadId
+- `In-Reply-To` header: original email's `Message-ID`
+- `References` header: original email's `References` + `Message-ID`
+- Subject: `Re: <original subject>` (if not already prefixed)

--- a/specs/003-gmail-agent/data-model.md
+++ b/specs/003-gmail-agent/data-model.md
@@ -1,0 +1,145 @@
+# Data Model: Gmail Automation Agent
+
+## Overview
+
+This feature does NOT add database models. All email data is pass-through from the Gmail API (no local storage). The data model defines TypeScript interfaces used internally by the `EmailService` and tool layer.
+
+## Entities
+
+### 1. GmailTokens
+
+Persisted in `backend/.gmail-tokens.json`. Keyed by user ID.
+
+```typescript
+interface GmailTokenStore {
+  [userId: string]: GmailTokenEntry;
+}
+
+interface GmailTokenEntry {
+  accessToken: string;
+  refreshToken: string;
+  expiryDate: number;        // Unix timestamp (ms)
+  scopes: string[];          // e.g. ['gmail.readonly', 'gmail.compose']
+  email: string;             // Gmail address for display
+  obtainedAt: string;        // ISO 8601 timestamp
+}
+```
+
+**Storage**: JSON file on disk (`backend/.gmail-tokens.json`).
+**Lifecycle**: Created on OAuth callback, updated on token refresh, deleted on user-initiated disconnect.
+**Validation**: `accessToken` and `refreshToken` must be non-empty strings. `expiryDate` must be a positive number.
+
+### 2. EmailSummary
+
+Returned by `read_emails`, `search_emails`, and `summarize_emails` tools.
+
+```typescript
+interface EmailSummary {
+  id: string;                // Gmail message ID
+  threadId: string;          // Gmail thread ID
+  from: {
+    name: string;            // Sender display name
+    address: string;         // Sender email address
+  };
+  to: string[];              // Recipient addresses
+  subject: string;           // Email subject line
+  date: string;              // ISO 8601 timestamp
+  snippet: string;           // Gmail's built-in ~200 char preview
+  isUnread: boolean;         // Based on UNREAD label
+  hasAttachments: boolean;   // True if any MIME parts are attachments
+  attachments?: AttachmentMeta[];  // Present only if hasAttachments
+  body?: string;             // Full plain-text body (only when includeBody=true)
+}
+
+interface AttachmentMeta {
+  filename: string;
+  mimeType: string;
+  size: number;              // Bytes
+}
+```
+
+**Source**: Constructed from Gmail API `users.messages.get` response.
+**No persistence**: Ephemeral, returned directly in tool output.
+
+### 3. EmailDraft
+
+Input to `draft_email` and `reply_email` tools. Represents a draft to be created in Gmail.
+
+```typescript
+interface EmailDraft {
+  to: string;                // Recipient email address
+  subject: string;           // Subject line
+  body: string;              // Plain text body
+  cc?: string;               // CC addresses (comma-separated)
+  bcc?: string;              // BCC addresses (comma-separated)
+}
+
+interface ReplyDraft {
+  emailId: string;           // Gmail message ID being replied to
+  body: string;              // Reply body text
+}
+```
+
+**Lifecycle**: Constructed from tool input, used to create Gmail draft via API, then discarded.
+
+### 4. DraftResult
+
+Returned by `draft_email` and `reply_email` tools after successful draft creation.
+
+```typescript
+interface DraftResult {
+  draftId: string;           // Gmail draft ID
+  threadId: string;          // Gmail thread ID (for replies)
+  to: string;                // Recipient
+  subject: string;           // Subject line
+  bodyPreview: string;       // First 200 chars of body
+}
+```
+
+### 5. EmailListResult
+
+Wrapper for paginated email results.
+
+```typescript
+interface EmailListResult {
+  emails: EmailSummary[];
+  totalCount: number;        // Total matching emails (not just returned page)
+  returnedCount: number;     // Number returned in this response
+}
+```
+
+## Relationships
+
+```
+GmailTokenStore
+  └── [userId] → GmailTokenEntry (1:1 per user)
+
+EmailService (runtime)
+  ├── uses GmailTokenEntry for auth
+  ├── returns EmailSummary[] for read/search
+  ├── accepts EmailDraft / ReplyDraft for compose
+  └── returns DraftResult for compose confirmation
+
+Tools (read_emails, search_emails, etc.)
+  └── delegate to EmailService
+  └── format results as string for tool output
+```
+
+## State Transitions
+
+### OAuth Token Lifecycle
+
+```
+[No Token] → OAuth Flow → [Active Token] → Expired → [Auto-Refresh] → [Active Token]
+                                                  → Refresh Failed → [Re-auth Required]
+                          [Active Token] → User Revokes → [Re-auth Required]
+```
+
+### Email Tool Data Flow
+
+```
+Tool Input (Zod-validated) → EmailService method → Gmail API call → Raw Response
+  → Parse to EmailSummary/DraftResult → Format as string → Tool Output
+```
+
+No data is cached or stored between requests. Each tool call is a fresh Gmail API round-trip.

--- a/specs/003-gmail-agent/plan.md
+++ b/specs/003-gmail-agent/plan.md
@@ -1,0 +1,262 @@
+# Implementation Plan: Gmail Automation Agent
+
+**Feature Branch**: `003-gmail-agent`
+**Spec**: `specs/003-gmail-agent/spec.md`
+**Status**: Ready for implementation
+
+## Technical Context
+
+| Aspect | Detail |
+|--------|--------|
+| Language | TypeScript (strict mode) |
+| Runtime | Node.js + Express (ts-node) |
+| Database | PostgreSQL + Prisma (NOT used for this feature — tokens in file) |
+| AI Integration | Agentic tool loop (`toolExecutor.ts`, max 10 iterations) |
+| Tool Pattern | `RunnableTool` interface with Zod validation |
+| Gmail API Client | `googleapis` npm package (already installed) |
+| HTML Processing | `html-to-text` npm package (already installed) |
+| Logging | pino with structured JSON + PII redaction |
+| Auth | Hardcoded dev user (`req.user.id`) — tools keyed by user ID |
+| Existing Reference | `googleCalendar.ts` — same OAuth2 + googleapis pattern |
+
+**No new dependencies required.** All packages already in `backend/package.json`.
+
+## Constitution Check
+
+### I. Code Quality (NON-NEGOTIABLE)
+
+- **TypeScript**: All new code in `backend/src/`. No new JS files. ✅
+- **Single responsibility**: `EmailService` for Gmail API, one file per tool, one file for auth routes. ✅
+- **Structured logging**: All Gmail operations use `logger.child({ tool: '...' })`. No `console.log`. ✅
+- **Dead code**: No unused exports or commented-out blocks. ✅
+- **Linting**: Must pass `npm run lint` before PR. ✅
+- **Function size**: Service methods and tool handlers stay under 50 lines each. ✅
+
+### II. Testing Standards
+
+- **Unit tests**: `EmailService` methods with mocked `googleapis` client. ✅
+- **Integration tests**: OAuth endpoints via supertest. ✅
+- **Tool tests**: Each tool with mocked `EmailService`. ✅
+- **Deterministic**: No external API calls in tests — all mocked. ✅
+- **Coverage**: Target 80% line coverage for new files. Critical paths (token refresh, error handling) at 100% branch. ✅
+
+### III. User Experience Consistency
+
+- **No frontend changes required**: Tools work through existing chat UI + agentic loop. ✅
+- **Tool feedback**: Existing SSE events (`tool_use_start`, `tool_use_result`) display tool execution in real-time. ✅
+- **Error messages**: All `ToolError` messages are user-actionable ("Gmail not connected. Visit..."). ✅
+
+### IV. Performance Requirements
+
+- **Tool timeouts**: `read_emails` 15s, `search_emails` 15s, `summarize_emails` 30s, `draft_email` 10s, `reply_email` 10s. ✅
+- **No in-memory caching**: Stateless per-request (NFR-003). ✅
+- **Token file I/O**: Synchronous-safe — file is <1KB, read once per tool call. ✅
+
+### Quality Gates
+
+- Lint Gate: `npm run lint` (backend) — zero errors. ✅
+- Type Gate: `npm run build` (backend) — zero TS errors. ✅
+- Test Gate: `npm test` (backend) — all green. ✅
+- Coverage Gate: 80% line coverage for new code. ✅
+- Security Gate: No hardcoded secrets, tokens in gitignored file, PII redacted from logs, Zod input validation on all tools. ✅
+
+## Architecture Decisions
+
+### AD-1: Token Storage
+
+**Decision**: JSON file (`backend/.gmail-tokens.json`) keyed by user ID.
+**Rationale**: Spec requires file-based storage (FR-002). Dynamic read without restart. Multi-user ready via user ID key (NFR-004).
+**See**: `research.md` §3
+
+### AD-2: OAuth2 Flow
+
+**Decision**: Server-side authorization code flow via Express routes.
+**Rationale**: User-initiated flow via browser. Follows spec requirement for `GET /api/v1/auth/gmail` endpoint.
+**See**: `research.md` §2, `contracts/oauth-endpoints.md`
+
+### AD-3: AI Summary Strategy
+
+**Decision**: Tool returns `snippet` (Gmail's 200-char preview). LLM generates summary naturally.
+**Rationale**: Avoids nested LLM calls inside tools. Tools are I/O-only. The agentic loop's LLM sees snippets and produces summaries.
+**See**: `research.md` §9
+
+### AD-4: No New Dependencies
+
+**Decision**: Use existing `googleapis` and `html-to-text` packages.
+**Rationale**: Both already in `package.json`. No bundle size impact.
+
+## Implementation Phases
+
+### Phase 1: Email Service Foundation (P0)
+
+**Goal**: Gmail API client with OAuth2 token management.
+
+**Files to create**:
+1. `backend/src/services/emailService.ts` — Singleton service with:
+   - `getAuthClient(userId)` — reads tokens from file, creates OAuth2 client, auto-refreshes if expired
+   - `saveTokens(userId, tokens)` — atomic write to `.gmail-tokens.json`
+   - `getTokens(userId)` — read from file
+   - `removeTokens(userId)` — delete user's tokens
+   - `isConnected(userId)` — check if valid tokens exist
+   - Private helpers for retry logic (exponential backoff on 429)
+
+**Files to modify**:
+1. `backend/.gitignore` — add `.gmail-tokens.json`
+2. `backend/src/config/logger.ts` — add email PII redaction paths (`emailBody`, `emailSubject`, `emailContent`, `body`, `subject`)
+
+**Tests**: `backend/tests/services/emailService.test.ts`
+- Token CRUD operations (read, write, delete)
+- Token refresh flow (mocked googleapis)
+- Error handling (expired token, revoked token, network error)
+- Retry logic for 429 responses
+
+### Phase 2: OAuth2 Routes (P0)
+
+**Goal**: Browser-based authorization flow.
+
+**Files to create**:
+1. `backend/src/routes/gmailAuthRoutes.ts` — Express router with:
+   - `GET /auth/gmail` — redirect to Google consent
+   - `GET /auth/gmail/callback` — exchange code for tokens, save to file
+   - `GET /auth/gmail/status` — return connection status
+
+**Files to modify**:
+1. `backend/src/server.ts` — mount `gmailAuthRoutes` under `/api/v1`
+
+**Tests**: `backend/tests/routes/gmailAuth.test.ts`
+- Redirect URL construction
+- Callback with valid code
+- Callback with denied access
+- Status endpoint (connected / not connected)
+
+### Phase 3: Read Tools (P1)
+
+**Goal**: `read_emails` and `search_emails` tools.
+
+**Files to create**:
+1. `backend/src/services/emailService.ts` — add methods:
+   - `listEmails(userId, filter, maxResults, dateRange?, includeBody?)` → `EmailListResult`
+   - `searchEmails(userId, params)` → `EmailListResult`
+   - `getEmail(userId, emailId, includeBody)` → `EmailSummary`
+   - Private helpers: `parseEmail(message)`, `extractBody(payload)`, `truncateBody(text, maxBytes)`
+
+2. `backend/src/tools/readEmails.ts` — `read_emails` tool
+3. `backend/src/tools/searchEmails.ts` — `search_emails` tool
+
+**Files to modify**:
+1. `backend/src/tools/index.ts` — register `readEmails`, `searchEmails`
+
+**Tests**:
+- `backend/tests/tools/readEmails.test.ts` — Zod validation, email formatting, error handling
+- `backend/tests/tools/searchEmails.test.ts` — query construction, result formatting
+- `backend/tests/services/emailService.test.ts` — add `listEmails`, `searchEmails` tests
+
+### Phase 4: Summarize Tool (P1)
+
+**Goal**: `summarize_emails` tool.
+
+**Files to create**:
+1. `backend/src/tools/summarizeEmails.ts` — `summarize_emails` tool (uses `emailService.listEmails` with higher maxResults)
+
+**Files to modify**:
+1. `backend/src/tools/index.ts` — register `summarizeEmails`
+
+**Tests**: `backend/tests/tools/summarizeEmails.test.ts`
+
+### Phase 5: Draft & Reply Tools (P1)
+
+**Goal**: `draft_email` and `reply_email` tools.
+
+**Files to create**:
+1. `backend/src/services/emailService.ts` — add methods:
+   - `createDraft(userId, draft)` → `DraftResult`
+   - `createReplyDraft(userId, emailId, body)` → `DraftResult`
+   - Private helpers: `buildMimeMessage(draft)`, `buildReplyMimeMessage(originalEmail, body)`
+
+2. `backend/src/tools/draftEmail.ts` — `draft_email` tool
+3. `backend/src/tools/replyEmail.ts` — `reply_email` tool
+
+**Files to modify**:
+1. `backend/src/tools/index.ts` — register `draftEmail`, `replyEmail`
+
+**Tests**:
+- `backend/tests/tools/draftEmail.test.ts` — validation, draft creation, error handling
+- `backend/tests/tools/replyEmail.test.ts` — thread context, headers, error handling
+- `backend/tests/services/emailService.test.ts` — add `createDraft`, `createReplyDraft` tests
+
+### Phase 6: Safety & Edge Cases
+
+**Goal**: Validate all guardrails from spec User Story 7.
+
+**Verification checklist**:
+- [ ] No tool has send capability — only draft creation (FR-011)
+- [ ] Default tool output has no email body — only metadata + snippet (FR-012)
+- [ ] `includeBody: true` returns body for explicit requests only
+- [ ] Email bodies redacted from pino logs (FR-013)
+- [ ] 50KB truncation with `[truncated]` marker (FR-014)
+- [ ] HTML→plaintext conversion via `html-to-text` (FR-015)
+- [ ] 429 retry with exponential backoff (FR-016)
+- [ ] Attachment metadata included (FR-019)
+- [ ] Token refresh on expired access token (FR-003)
+- [ ] Clear error on revoked refresh token (Scenario 1.4)
+- [ ] OAuth scopes are `gmail.readonly` + `gmail.compose` only (FR-001)
+- [ ] UTF-8 handling for international content
+- [ ] `.gmail-tokens.json` in `.gitignore`
+
+**Tests**: Safety-specific test cases in existing test files.
+
+## File Summary
+
+### New Files (8)
+
+| File | Description |
+|------|-------------|
+| `backend/src/services/emailService.ts` | Gmail API client + token management |
+| `backend/src/routes/gmailAuthRoutes.ts` | OAuth2 flow endpoints |
+| `backend/src/tools/readEmails.ts` | `read_emails` tool |
+| `backend/src/tools/searchEmails.ts` | `search_emails` tool |
+| `backend/src/tools/summarizeEmails.ts` | `summarize_emails` tool |
+| `backend/src/tools/draftEmail.ts` | `draft_email` tool |
+| `backend/src/tools/replyEmail.ts` | `reply_email` tool |
+| `backend/.gmail-tokens.json` | Token storage (gitignored, created at runtime) |
+
+### Modified Files (3)
+
+| File | Change |
+|------|--------|
+| `backend/src/tools/index.ts` | Register 5 new email tools |
+| `backend/src/server.ts` | Mount `gmailAuthRoutes` |
+| `backend/src/config/logger.ts` | Add email PII redaction paths |
+
+### Test Files (4)
+
+| File | Covers |
+|------|--------|
+| `backend/tests/services/emailService.test.ts` | Token CRUD, Gmail API methods, retry logic |
+| `backend/tests/routes/gmailAuth.test.ts` | OAuth flow endpoints |
+| `backend/tests/tools/readEmails.test.ts` | read_emails + searchEmails tools |
+| `backend/tests/tools/draftEmail.test.ts` | draft_email + replyEmail tools |
+
+### Unchanged Existing Files
+
+- `backend/src/tools/types.ts` — `RunnableTool` interface is sufficient
+- `backend/src/services/toolRegistry.ts` — no changes needed
+- `backend/src/services/toolExecutor.ts` — agentic loop handles new tools automatically
+- All frontend files — tools work through existing chat UI
+- `backend/prisma/schema.prisma` — no database changes
+
+## Dependencies Between Phases
+
+```
+Phase 1 (EmailService) ──→ Phase 2 (OAuth Routes)
+         │
+         ├──→ Phase 3 (Read/Search Tools)
+         │         │
+         │         └──→ Phase 4 (Summarize Tool)
+         │
+         └──→ Phase 5 (Draft/Reply Tools)
+                  │
+                  └──→ Phase 6 (Safety Verification)
+```
+
+Phase 1 is the foundation. Phases 3-5 can be parallelized after Phase 1. Phase 6 runs last as a cross-cutting verification.

--- a/specs/003-gmail-agent/quickstart.md
+++ b/specs/003-gmail-agent/quickstart.md
@@ -1,0 +1,88 @@
+# Quickstart: Gmail Automation Agent
+
+## Prerequisites
+
+1. **Google Cloud Project** with Gmail API enabled (reuses existing project from Google Calendar setup).
+2. `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `backend/.env` (already configured for Calendar).
+3. **OAuth redirect URI** registered in Google Cloud Console: `http://localhost:5001/api/v1/auth/gmail/callback`.
+4. Docker services running (`docker-compose up`) or local PostgreSQL + SearXNG.
+
+## Setup Steps
+
+### 1. Enable Gmail API
+
+In Google Cloud Console → APIs & Services → Enable "Gmail API" on the existing project.
+
+### 2. Add OAuth Redirect URI
+
+In Google Cloud Console → Credentials → OAuth 2.0 Client → Add authorized redirect URI:
+```
+http://localhost:5001/api/v1/auth/gmail/callback
+```
+
+### 3. Start the Server
+
+```bash
+cd backend
+npm run dev
+```
+
+### 4. Authorize Gmail
+
+Visit in your browser:
+```
+http://localhost:5001/api/v1/auth/gmail
+```
+
+Complete the Google OAuth consent flow. On success, you'll see "Gmail Connected" and can close the tab.
+
+### 5. Use Gmail Tools in Chat
+
+Open the chat UI at `http://localhost:3000` and try:
+
+- "Show me my unread emails"
+- "Find emails from john@example.com about the project update"
+- "Summarize my inbox"
+- "Draft an email to jane@example.com about rescheduling our meeting to Friday"
+- "Reply to Sarah's email about the deadline"
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `src/services/emailService.ts` | Gmail API client, OAuth token management, all Gmail operations |
+| `src/routes/gmailAuthRoutes.ts` | OAuth2 flow endpoints (initiate, callback, status) |
+| `src/tools/readEmails.ts` | `read_emails` tool |
+| `src/tools/searchEmails.ts` | `search_emails` tool |
+| `src/tools/summarizeEmails.ts` | `summarize_emails` tool |
+| `src/tools/draftEmail.ts` | `draft_email` tool |
+| `src/tools/replyEmail.ts` | `reply_email` tool |
+| `src/tools/index.ts` | Tool registration (add new tools here) |
+| `.gmail-tokens.json` | OAuth tokens (gitignored, created on first auth) |
+
+## Verification
+
+Check Gmail connection status:
+```bash
+curl http://localhost:5001/api/v1/auth/gmail/status
+```
+
+Expected (before auth):
+```json
+{"connected": false, "authorizeUrl": "/api/v1/auth/gmail"}
+```
+
+Expected (after auth):
+```json
+{"connected": true, "email": "you@gmail.com", "scopes": ["gmail.readonly", "gmail.compose"]}
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Google OAuth not configured" | Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `backend/.env` |
+| "redirect_uri_mismatch" | Add `http://localhost:5001/api/v1/auth/gmail/callback` in Google Cloud Console |
+| "Gmail not connected" error in chat | Visit `http://localhost:5001/api/v1/auth/gmail` to authorize |
+| Token refresh fails | User may have revoked access in Google Account settings. Re-authorize. |
+| 429 rate limit | Gmail API quota exceeded. Wait a few minutes, or check quota in Cloud Console. |

--- a/specs/003-gmail-agent/research.md
+++ b/specs/003-gmail-agent/research.md
@@ -1,0 +1,137 @@
+# Research: Gmail Automation Agent
+
+## 1. Gmail API OAuth2 Scopes
+
+**Decision**: Use `gmail.readonly` + `gmail.compose` scopes only.
+
+**Rationale**:
+- `gmail.readonly` (`https://www.googleapis.com/auth/gmail.readonly`) grants read access to all messages, threads, labels, and settings. Sufficient for `read_emails`, `search_emails`, and `summarize_emails` tools.
+- `gmail.compose` (`https://www.googleapis.com/auth/gmail.compose`) grants permission to create, read, update, and delete drafts, as well as send messages. However, the application will only use draft creation — sending is explicitly excluded at the application layer (FR-011).
+- `gmail.modify` is NOT needed. `gmail.compose` alone supports `users.drafts.create`.
+- `gmail.send` scope is NOT requested per spec (SC-006 safety guardrail). The `gmail.compose` scope technically allows sending via `users.messages.send`, but the application will NOT expose any send tool — safety is enforced at the tool layer, not the scope layer. This is a pragmatic choice: `gmail.compose` is the narrowest scope that supports draft creation.
+
+**Alternatives considered**:
+- `gmail.modify` — overly broad (allows label changes, marking read/unread). Not needed.
+- Restricting to `gmail.readonly` only — would prevent draft creation entirely.
+- Using restricted scopes (`gmail.addons.current.message.readonly`) — too narrow, doesn't cover search or listing.
+
+## 2. OAuth2 Flow Architecture
+
+**Decision**: Server-side OAuth2 authorization code flow via a dedicated Express route (`GET /api/v1/auth/gmail` + `GET /api/v1/auth/gmail/callback`).
+
+**Rationale**:
+- Follows the same pattern as the existing Google Calendar tool which uses `googleapis` OAuth2 client.
+- The existing `.env` already contains `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REFRESH_TOKEN` — the Calendar tool uses a pre-obtained refresh token. For Gmail, we add a proper OAuth flow endpoint so the user can authorize in-browser.
+- Redirect URI: `http://localhost:5001/api/v1/auth/gmail/callback` (must be registered in Google Cloud Console).
+- On successful authorization, tokens are written to a JSON config file (`backend/.gmail-tokens.json`), NOT to `.env` (writing to `.env` would require restart; a JSON file can be read dynamically).
+- The token file is added to `.gitignore`.
+
+**Alternatives considered**:
+- Storing tokens in `.env` — requires server restart after authorization. Poor DX.
+- Storing tokens in PostgreSQL — spec explicitly says no database storage for tokens (FR-002, Clarification: "No. Pass-through from Gmail API, no local storage"). A local config file is specified.
+- Manual token generation via CLI script (like current Calendar approach) — works but poor UX. The spec requests `GET /api/v1/auth/gmail` endpoint.
+
+## 3. Token Storage & Refresh Strategy
+
+**Decision**: JSON file (`backend/.gmail-tokens.json`) with structure `{ "<userId>": { accessToken, refreshToken, expiryDate, scopes } }`. Keyed by user ID for multi-user readiness (NFR-004).
+
+**Rationale**:
+- File-based storage aligns with FR-002: "stored persistently in a local config file."
+- Keyed by user ID satisfies NFR-004: "support multiple users without code changes."
+- The `EmailService` reads tokens from file on each request (NFR-003: stateless per-request, no in-memory caching).
+- Auto-refresh: before each Gmail API call, check `expiryDate`. If expired, use `refreshToken` to obtain new `accessToken`, update the file atomically.
+- If refresh fails (revoked token), return clear error: "Gmail authorization expired. Visit GET /api/v1/auth/gmail to re-authorize." (Scenario 1.4).
+
+**Alternatives considered**:
+- In-memory token cache with file persistence — would break NFR-003 (stateless per-request). However, reading from file on every tool call is acceptable for single-user local dev.
+- Encrypted storage — NFR-002 says "Encryption at rest is not required for local dev."
+
+## 4. Gmail API Client Pattern
+
+**Decision**: Singleton `EmailService` class with per-request OAuth2 client instantiation. Located at `backend/src/services/emailService.ts`.
+
+**Rationale**:
+- FR-018 mandates a standalone module encapsulating all Gmail API interactions.
+- Per-request OAuth2 client creation ensures fresh tokens and statelessness (NFR-003).
+- The service exposes methods: `listEmails()`, `searchEmails()`, `getEmail()`, `createDraft()`, `createReplyDraft()`.
+- Each method accepts a `userId` parameter for multi-user readiness.
+- The service handles retry logic for 429 errors (FR-016: exponential backoff, max 3 retries).
+
+**Alternatives considered**:
+- Static utility functions — doesn't provide the encapsulation FR-018 requires.
+- Per-tool Gmail client — would duplicate auth logic across 5 tools. Violates single responsibility.
+
+## 5. Email Body Processing
+
+**Decision**: Use `html-to-text` (already a dependency) for HTML→plaintext conversion. Truncate at 50KB.
+
+**Rationale**:
+- `html-to-text` is already in `backend/package.json` (used by `fetchUrl` tool). No new dependency.
+- FR-015: HTML-only emails must be converted to plain text.
+- FR-014: Emails exceeding 50KB must be truncated with `[truncated]` marker.
+- Processing pipeline: raw email → extract `text/plain` part (prefer) → fallback to `text/html` → convert with `html-to-text` → truncate at 50KB.
+
+**Alternatives considered**:
+- Custom regex-based HTML stripping — fragile, misses edge cases (tables, encoded entities).
+- Sending raw HTML to LLM — wastes tokens, LLM doesn't need HTML formatting.
+
+## 6. Tool Interface Pattern
+
+**Decision**: Follow existing `RunnableTool` interface exactly. Each tool is a separate file exporting a `RunnableTool` instance with Zod schema.
+
+**Rationale**:
+- FR-017 mandates following the existing `RunnableTool` interface.
+- SC-007 specifies exact file locations: `src/tools/readEmails.ts`, `src/tools/searchEmails.ts`, etc.
+- Each tool validates input via Zod, delegates to `EmailService`, and returns formatted string output.
+- Tool timeouts per spec: 15s for read/search, 30s for summarize, 10s for draft/reply.
+
+**Pattern** (matches `googleCalendar.ts`):
+```
+export const readEmails: RunnableTool<z.infer<typeof schema>> = {
+  definition: { name, description, input_schema },
+  schema,
+  timeoutMs: 15000,
+  async run(input) { ... }
+};
+```
+
+## 7. Logging & PII Redaction
+
+**Decision**: Add Gmail-specific redaction paths to pino config. Email tool logs include operation name, duration, result count, user ID — never email content.
+
+**Rationale**:
+- FR-013: "Email body content and subjects MUST be redacted from server logs."
+- NFR-005: "All Gmail API calls MUST include structured logging."
+- Add to existing pino redaction paths: `emailBody`, `emailSubject`, `emailContent`.
+- Tool logs use the existing `logger.child({ tool: 'tool_name' })` pattern.
+
+**Alternatives considered**:
+- Separate logger for email tools — unnecessary complexity. Pino redaction handles it globally.
+
+## 8. Error Handling for Gmail API
+
+**Decision**: Map Gmail API error codes to `ToolError` messages. Implement exponential backoff for 429s.
+
+**Rationale**:
+- FR-016: 429 responses must be handled with exponential backoff (max 3 retries).
+- Token errors (401/403) → clear re-authorization message.
+- Network errors → generic "Gmail API unavailable" message.
+- Follows existing pattern in `googleCalendar.ts` (catch, check error code, throw `ToolError`).
+
+**Backoff strategy**: delays of 1s, 2s, 4s. If all 3 retries exhausted, throw `ToolError` with "Gmail rate limit exceeded. Please try again in a few minutes."
+
+## 9. LLM Summary Generation
+
+**Decision**: The `read_emails` and `search_emails` tools fetch email bodies server-side, generate a one-line summary as part of the tool output, but do NOT include the full body in the tool result (unless `includeBody: true`).
+
+**Rationale**:
+- FR-005: tool must return `summary` (AI-generated one-liner).
+- FR-012: body content must NOT appear in tool output by default.
+- The "AI-generated summary" is produced by the LLM itself during the agentic loop. The tool returns metadata + the Gmail `snippet` field. The LLM sees the snippet and produces a natural language summary in its response.
+- This avoids a second LLM call inside the tool (which would be slow, expensive, and architecturally wrong — tools should be pure I/O, not AI).
+
+**Clarification**: The spec says "AI-generated one-line summary" — this is the LLM's natural behavior when given email metadata + snippet. The tool provides `snippet` (Gmail's built-in 200-char preview), and the LLM summarizes. When the user asks to "open" or "read" a specific email, the tool returns the full body via `includeBody`.
+
+**Alternatives considered**:
+- Calling the LLM inside the tool to generate summaries — adds latency (each email = 1 LLM call), breaks the architecture (tools are I/O), and is unnecessary since the LLM will summarize naturally.
+- Returning full bodies always — wastes tokens, violates FR-012 privacy requirement.

--- a/specs/003-gmail-agent/spec.md
+++ b/specs/003-gmail-agent/spec.md
@@ -150,7 +150,7 @@ The system must enforce privacy and safety boundaries: metadata-only access by d
 - **FR-002**: OAuth2 tokens (access token, refresh token, expiry) MUST be stored persistently in a local config file (e.g., `.env` or JSON config). Single-user scope — no database table required.
 - **FR-003**: Access tokens MUST be refreshed automatically when expired — no user intervention for routine token renewal.
 - **FR-004**: The `read_emails` tool MUST accept parameters: `filter` (unread, read, all), `maxResults` (default 20, max 50), and `dateRange` (optional).
-- **FR-005**: The `read_emails` tool MUST return per-email: `id`, `threadId`, `from` (name + address), `subject`, `date`, `snippet` (Gmail's built-in snippet), and `summary` (AI-generated one-liner).
+- **FR-005**: The `read_emails` tool MUST return per-email: `id`, `threadId`, `from` (name + address), `subject`, `date`, and `snippet` (Gmail's built-in ~200 character preview). The LLM generates human-readable summaries naturally from the snippet — no separate `summary` field in the tool output.
 - **FR-006**: The `search_emails` tool MUST accept parameters: `from`, `to`, `subject`, `keywords`, `dateRange` (after/before), `hasAttachment`, and `maxResults`.
 - **FR-007**: The `search_emails` tool MUST construct Gmail API search queries from structured parameters — NOT pass raw Gmail query syntax from the user.
 - **FR-008**: The `summarize_emails` tool MUST fetch up to 50 emails and return them for the LLM to categorize and summarize.
@@ -178,7 +178,7 @@ The system must enforce privacy and safety boundaries: metadata-only access by d
 
 - **EmailService**: Singleton service encapsulating Gmail API client, OAuth2 token management, and all Gmail operations. Keyed by user ID for multi-user readiness.
 - **GmailToken**: Stored credential containing access token, refresh token, and expiry timestamp. Persisted in a local config file (not database).
-- **EmailSummary**: The data shape returned by read/search tools: `id`, `threadId`, `from`, `subject`, `date`, `snippet`, `summary`, `hasAttachments`, `attachments[]?`.
+- **EmailSummary**: The data shape returned by read/search tools: `id`, `threadId`, `from`, `subject`, `date`, `snippet`, `hasAttachments`, `attachments[]?`.
 - **EmailDraft**: The data shape for draft creation: `to`, `subject`, `body`, `cc?`, `bcc?`, `threadId?` (for replies), `inReplyTo?`, `references?`.
 
 ### Tools Summary

--- a/specs/003-gmail-agent/spec.md
+++ b/specs/003-gmail-agent/spec.md
@@ -1,0 +1,228 @@
+# Feature Specification: Gmail Automation Agent
+
+**Feature Branch**: `003-gmail-agent`
+**Created**: 2026-07-12
+**Status**: Draft
+**Input**: User wants an AI-powered Gmail automation agent that can read, search, summarize, draft, and reply to emails through the existing chat UI. Drafts are saved to Gmail for user review — no auto-sending.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Gmail OAuth2 Connection (Priority: P0)
+
+A user needs to connect their Gmail account before any email tools work. The system must handle OAuth2 authorization, token storage, and automatic token refresh. Since the system is single-user today but must be multi-user ready, token management is keyed by user ID.
+
+**Why this priority**: Nothing works without authentication. This is the foundation for every other story.
+
+**Independent Test**: Complete the OAuth2 flow, store tokens, restart the server, and verify the stored refresh token automatically obtains a new access token without re-authorization.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with no Gmail connection, **When** they attempt to use any email tool, **Then** the tool returns a clear error: "Gmail not connected. Visit GET /api/v1/auth/gmail to authorize."
+2. **Given** a valid OAuth2 authorization code, **When** the token exchange completes, **Then** access token, refresh token, and expiry are persisted (encrypted at rest) keyed by user ID.
+3. **Given** a stored access token that has expired, **When** any email tool is invoked, **Then** the service automatically refreshes the token using the stored refresh token — no user intervention required.
+4. **Given** a refresh token that has been revoked by the user in Google settings, **When** any email tool is invoked, **Then** the system returns a clear error indicating re-authorization is needed (not a generic 401).
+
+---
+
+### User Story 2 - Read Inbox (Priority: P1)
+
+A user asks "show me my unread emails" or "show me recent emails." The agent fetches email metadata (sender, subject, date) and the body text, then returns a list with an AI-generated one-line summary per email.
+
+**Why this priority**: Reading is the most fundamental email operation and the prerequisite for search, summarize, and reply.
+
+**Independent Test**: Ask "show me my unread emails" and verify the response lists emails with sender, subject, date, and a one-line AI summary — without exposing full email bodies unless explicitly requested.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user asks "show me my unread emails," **When** the tool executes, **Then** it returns a list of unread emails with: sender name/address, subject, date, and a one-line AI-generated summary.
+2. **Given** an inbox with 100+ unread emails, **When** the tool executes without a limit parameter, **Then** it returns the 20 most recent by default and indicates the total count.
+3. **Given** a user asks "show me emails from this week," **When** the tool executes, **Then** it filters by the date range and returns matching emails.
+4. **Given** the default read mode, **When** the tool fetches emails, **Then** it reads the full body to generate the summary but only returns metadata + summary to the LLM — the full body is NOT included in the tool output unless the user explicitly asks to "read" or "open" a specific email.
+5. **Given** no unread emails, **When** the tool executes, **Then** it returns a clear "no unread emails found" message — not an error.
+
+---
+
+### User Story 3 - Search Emails (Priority: P1)
+
+A user asks "find emails from Sarah about the Q3 report" or "search for invoices from last month." The agent translates this into a Gmail search query and returns matching emails with summaries.
+
+**Why this priority**: Search is essential for locating specific emails to reply to or reference.
+
+**Independent Test**: Ask "find emails from john@example.com about project update" and verify the tool constructs the correct Gmail query and returns relevant results with summaries.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user asks "find emails from sarah@company.com," **When** the tool executes, **Then** it constructs a Gmail API query with `from:sarah@company.com` and returns matching emails.
+2. **Given** a user asks "find emails about quarterly report from last month," **When** the tool executes, **Then** it constructs a query combining subject/body keywords and date range (`after:` / `before:` operators).
+3. **Given** a search with zero results, **When** the tool responds, **Then** it returns "no emails found matching your search" — not an error.
+4. **Given** a search returning 50+ results, **When** the tool executes, **Then** it returns the top 20 most relevant by default and indicates more are available.
+5. **Given** a natural language search query, **When** the LLM invokes the tool, **Then** the LLM translates intent into structured parameters (from, subject, keywords, dateRange) — the tool does NOT parse natural language itself.
+
+---
+
+### User Story 4 - Summarize Emails (Priority: P1)
+
+A user asks "summarize my inbox" or "categorize my unread emails." The agent reads a batch of emails and produces a categorized summary (e.g., "3 meeting invitations, 2 action items from your manager, 5 newsletters").
+
+**Why this priority**: Inbox summarization is the highest-value AI feature — it saves the user from reading dozens of emails.
+
+**Independent Test**: Ask "summarize my unread inbox" and verify the response groups emails into meaningful categories with counts and highlights.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user asks "summarize my inbox," **When** the tool fetches unread emails, **Then** the LLM categorizes them (e.g., action required, FYI, newsletters, meeting invites) and returns a structured summary.
+2. **Given** 30 unread emails, **When** the summarize tool runs, **Then** it processes all 30 (not just the default 20 page) to produce a complete summary.
+3. **Given** the summarize tool output, **When** the LLM presents it, **Then** each category includes a count and the most important items highlighted.
+4. **Given** an empty inbox, **When** the tool runs, **Then** it returns "inbox is empty — no emails to summarize."
+
+---
+
+### User Story 5 - Draft New Email (Priority: P1)
+
+A user asks "draft an email to john@example.com about rescheduling our meeting to Friday." The agent composes the email and saves it as a draft in Gmail. The user reviews and sends from Gmail.
+
+**Why this priority**: Drafting is the core write operation and must be safe-by-default (never auto-send).
+
+**Independent Test**: Ask the agent to draft an email, verify it appears in Gmail Drafts with correct recipient, subject, and body, and confirm no email was sent.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user asks "draft an email to john@example.com about rescheduling," **When** the tool executes, **Then** it creates a draft in Gmail with the specified recipient, an appropriate subject line, and a composed body.
+2. **Given** the draft is saved, **When** the tool responds, **Then** it confirms "Draft saved to Gmail" and shows the recipient, subject, and a preview of the body in the chat.
+3. **Given** the user provides only a recipient and a topic (no explicit body), **When** the LLM invokes the tool, **Then** it generates appropriate subject and body content based on the topic.
+4. **Given** the user says "send it" after seeing the draft, **When** the agent processes this, **Then** it does NOT send the email. It reminds the user to send from Gmail. (Sending is not a v1 feature.)
+5. **Given** an invalid email address, **When** the tool attempts to create the draft, **Then** it returns a validation error before calling the Gmail API.
+
+---
+
+### User Story 6 - Reply to Email (Priority: P1)
+
+A user asks "reply to Sarah's email about the project deadline." The agent finds the email, reads the thread context, composes a contextual reply, and saves it as a draft in Gmail.
+
+**Why this priority**: Contextual replies are the second core write operation and require thread-awareness.
+
+**Independent Test**: Ask the agent to reply to a specific email, verify it creates a Gmail draft in the correct thread with proper `In-Reply-To` and `References` headers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user asks "reply to Sarah's last email about the deadline," **When** the agent processes this, **Then** it first searches for the email, reads the thread context, composes a reply, and saves it as a draft in the correct Gmail thread.
+2. **Given** the reply draft is saved, **When** the tool responds, **Then** it shows the original email subject, the reply body preview, and confirms "Reply draft saved to Gmail."
+3. **Given** an ambiguous reference ("reply to John's email"), **When** multiple emails from John exist, **Then** the agent lists the recent matches and asks the user to clarify which one.
+4. **Given** a thread with 10 messages, **When** the agent composes a reply, **Then** it uses the thread context to write a relevant response — not a generic reply.
+5. **Given** a reply request, **When** the draft is created, **Then** it includes proper email threading headers (`In-Reply-To`, `References`) so the reply appears in the correct Gmail thread.
+
+---
+
+### User Story 7 - Safety Guardrails (Priority: P0)
+
+The system must enforce privacy and safety boundaries: metadata-only access by default, no auto-sending, and clear boundaries on what the AI can read.
+
+**Why this priority**: Safety is non-negotiable. Incorrect guardrails could expose sensitive email content or send unintended emails.
+
+**Independent Test**: Verify that the tool output for a `read_emails` call contains only metadata + AI summary (not raw bodies), and that no tool in the system can send an email.
+
+**Acceptance Scenarios**:
+
+1. **Given** the default `read_emails` call, **When** the tool returns results, **Then** the tool output contains sender, subject, date, and AI summary — NOT the full email body.
+2. **Given** a user asks "read the full email from John about the contract," **When** the user explicitly requests body access, **Then** the tool includes the full body for that specific email only.
+3. **Given** any tool in the email system, **When** examining its capabilities, **Then** no tool has the ability to send an email (only create drafts).
+4. **Given** the Gmail OAuth scopes, **When** the service initializes, **Then** it requests `gmail.readonly`, `gmail.compose`, and `gmail.modify` — NOT `gmail.send` in v1. (Note: `gmail.compose` allows draft creation; `gmail.modify` is NOT needed. If `gmail.compose` alone cannot create drafts, use the minimum scope that allows it.)
+5. **Given** a tool call that returns email content, **When** the response is logged, **Then** email bodies and subjects are NOT written to server logs (PII redaction).
+
+---
+
+### Edge Cases
+
+- **Expired/revoked tokens**: The system MUST detect expired tokens and attempt refresh. If refresh fails, it MUST return a clear "re-authorize Gmail" error — not a cryptic API failure.
+- **Gmail API rate limits**: The system MUST handle 429 responses gracefully with exponential backoff and a user-facing message if the limit cannot be satisfied.
+- **Large emails**: Emails with bodies exceeding 50KB of text MUST be truncated with a "[truncated]" marker to avoid blowing the LLM context window.
+- **HTML-only emails**: Emails with no plain text part MUST be converted to plain text (strip HTML tags) before processing.
+- **Emails with attachments**: Attachment metadata (filename, size, type) MUST be included in the email summary. Attachment content is NOT downloaded or processed in v1.
+- **Non-ASCII content**: The system MUST handle UTF-8 encoded emails (international characters, emoji) without corruption.
+- **Thread with mixed participants**: When replying, the draft MUST reply to the correct sender — not to yourself or an unrelated participant.
+- **Concurrent tool calls**: If `read_emails` and `search_emails` are called in parallel by the agentic loop, they MUST NOT interfere with each other (stateless API calls).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST authenticate with Gmail using OAuth2 with the minimum required scopes: `gmail.readonly` and `gmail.compose`.
+- **FR-002**: OAuth2 tokens (access token, refresh token, expiry) MUST be stored persistently in a local config file (e.g., `.env` or JSON config). Single-user scope — no database table required.
+- **FR-003**: Access tokens MUST be refreshed automatically when expired — no user intervention for routine token renewal.
+- **FR-004**: The `read_emails` tool MUST accept parameters: `filter` (unread, read, all), `maxResults` (default 20, max 50), and `dateRange` (optional).
+- **FR-005**: The `read_emails` tool MUST return per-email: `id`, `threadId`, `from` (name + address), `subject`, `date`, `snippet` (Gmail's built-in snippet), and `summary` (AI-generated one-liner).
+- **FR-006**: The `search_emails` tool MUST accept parameters: `from`, `to`, `subject`, `keywords`, `dateRange` (after/before), `hasAttachment`, and `maxResults`.
+- **FR-007**: The `search_emails` tool MUST construct Gmail API search queries from structured parameters — NOT pass raw Gmail query syntax from the user.
+- **FR-008**: The `summarize_emails` tool MUST fetch up to 50 emails and return them for the LLM to categorize and summarize.
+- **FR-009**: The `draft_email` tool MUST accept: `to`, `subject`, `body`, `cc` (optional), `bcc` (optional) — and create a draft in the user's Gmail Drafts folder.
+- **FR-010**: The `reply_email` tool MUST accept: `emailId` (the email being replied to), `body` — and create a draft reply in the correct Gmail thread with proper `In-Reply-To` and `References` headers.
+- **FR-011**: No tool in the email system MUST have the capability to send an email. All compose operations create drafts only.
+- **FR-012**: Email body content MUST NOT appear in tool output by default. The tool returns metadata + AI summary. Full body is returned only when the user explicitly requests it via a `includeBody` parameter.
+- **FR-013**: Email body content and subjects MUST be redacted from server logs (Pino redaction paths).
+- **FR-014**: Emails exceeding 50KB of text content MUST be truncated before processing.
+- **FR-015**: HTML-only emails MUST be converted to plain text before processing.
+- **FR-016**: Gmail API 429 (rate limit) responses MUST be handled with exponential backoff (max 3 retries) and a user-facing error if retries are exhausted.
+- **FR-017**: All email tools MUST follow the existing `RunnableTool` interface with Zod input validation and per-tool timeouts.
+- **FR-018**: The email service layer MUST be a standalone module (`src/services/emailService.ts`) encapsulating all Gmail API interactions — no Gmail API calls outside this module.
+- **FR-019**: Attachment metadata (filename, size, MIME type) MUST be included in email data when present. Attachment content is NOT downloaded.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Each email tool call MUST complete within 15 seconds (tool timeout). Batch operations (summarize 50 emails) MUST complete within 30 seconds.
+- **NFR-002**: OAuth2 tokens are stored in a local config file. The file SHOULD be excluded from version control (`.gitignore`). Encryption at rest is not required for local dev — tokens are protected by file system permissions.
+- **NFR-003**: The email service MUST be stateless per-request — no in-memory caching of email data between tool calls. (Gmail API is the source of truth.)
+- **NFR-004**: The architecture MUST support multiple users without code changes — only the token lookup needs a user ID parameter.
+- **NFR-005**: All Gmail API calls MUST include structured logging: operation name, duration, result count, and user ID — but NOT email content.
+
+### Key Entities
+
+- **EmailService**: Singleton service encapsulating Gmail API client, OAuth2 token management, and all Gmail operations. Keyed by user ID for multi-user readiness.
+- **GmailToken**: Stored credential containing access token, refresh token, and expiry timestamp. Persisted in a local config file (not database).
+- **EmailSummary**: The data shape returned by read/search tools: `id`, `threadId`, `from`, `subject`, `date`, `snippet`, `summary`, `hasAttachments`, `attachments[]?`.
+- **EmailDraft**: The data shape for draft creation: `to`, `subject`, `body`, `cc?`, `bcc?`, `threadId?` (for replies), `inReplyTo?`, `references?`.
+
+### Tools Summary
+
+| Tool | Input Parameters | Output | Timeout |
+|------|-----------------|--------|---------|
+| `read_emails` | `filter`, `maxResults`, `dateRange?` | `EmailSummary[]` + total count | 15s |
+| `search_emails` | `from?`, `to?`, `subject?`, `keywords?`, `dateRange?`, `hasAttachment?`, `maxResults` | `EmailSummary[]` + total count | 15s |
+| `summarize_emails` | `filter?`, `maxResults` (up to 50) | Raw `EmailSummary[]` for LLM to categorize | 30s |
+| `draft_email` | `to`, `subject`, `body`, `cc?`, `bcc?` | Draft ID + confirmation | 10s |
+| `reply_email` | `emailId`, `body` | Draft ID + thread subject + confirmation | 10s |
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can ask "show me my unread emails" and receive a formatted list with AI summaries within 15 seconds.
+- **SC-002**: A user can ask "draft an email to X about Y" and find the draft in their Gmail Drafts folder with correct recipient, subject, and body.
+- **SC-003**: A user can ask "reply to [specific email]" and find a contextual reply draft in the correct Gmail thread.
+- **SC-004**: No email body content appears in server logs under any code path.
+- **SC-005**: OAuth2 token refresh works transparently — the user authorizes once and never re-authorizes unless they revoke access.
+- **SC-006**: All 5 email tools pass Zod input validation and follow the `RunnableTool` interface.
+- **SC-007**: The entire email feature is contained in: `src/services/emailService.ts`, `src/tools/readEmails.ts`, `src/tools/searchEmails.ts`, `src/tools/summarizeEmails.ts`, `src/tools/draftEmail.ts`, `src/tools/replyEmail.ts`, and registration in `src/tools/index.ts` — no changes to existing tool or service files beyond registration.
+
+## Clarifications
+
+### Session 2026-07-12
+
+- Q: Should drafts be shown in the chat UI or saved to Gmail? → A: Saved to Gmail Drafts. User reviews and sends from Gmail.
+- Q: AI-generated summary vs. Gmail snippet? → A: AI-generated one-line summary per email. Gmail snippet is included as fallback metadata.
+- Q: Should the AI read full email bodies by default? → A: No. Metadata only by default. Full body only when user explicitly asks to "read" or "open" a specific email.
+- Q: Should the system auto-send emails? → A: No. Drafts only in v1. If user says "send it," remind them to send from Gmail.
+- Q: Should email data be stored in PostgreSQL? → A: No. Pass-through from Gmail API, no local storage.
+- Q: Single user or multi-user? → A: Single user now, but architecture must support multi-user with no code changes (user ID keyed).
+- Q: Standalone service or integrated? → A: Integrated into existing tool system with a dedicated email service layer.
+- Q: How does the user initiate OAuth2 authorization? → A: Dedicated server endpoint (`GET /api/v1/auth/gmail`) that initiates the OAuth redirect flow. User visits the URL in a browser.
+- Q: Where are OAuth2 tokens stored? → A: Environment/config file (e.g., `.env` or a local config file). Single-user only — no database table for tokens.
+- Q: Reuse existing Google Cloud credentials or new ones? → A: Reuse existing `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. Gmail API is an additional scope on the same Google Cloud project.
+
+## Assumptions
+
+- The user already has Google Cloud project credentials with Gmail API enabled (reuses existing `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` from the calendar tool setup).
+- Gmail API quotas (250 units/second default) are sufficient for single-user usage.
+- The existing agentic tool loop (10 iteration max) is sufficient for email workflows — no need for a separate orchestration layer.
+- The LLM (not the tool) handles natural language understanding — tools receive structured parameters.
+- Email content is ephemeral — not stored in the database, not cached between requests.
+- The existing `google-auth.ts` script can be extended for Gmail scopes, or a new authorization endpoint can be added.

--- a/specs/003-gmail-agent/tasks.md
+++ b/specs/003-gmail-agent/tasks.md
@@ -1,0 +1,167 @@
+# Tasks: Gmail Automation Agent
+
+**Feature Branch**: `003-gmail-agent`
+**Generated**: 2026-07-12
+**Spec**: `specs/003-gmail-agent/spec.md`
+**Plan**: `specs/003-gmail-agent/plan.md`
+
+## Summary
+
+- **Total Tasks**: 36
+- **Phases**: 7 (Setup, Foundation, US1 OAuth, US2 Read Inbox, US3 Search, US4 Summarize + US5 Draft + US6 Reply, US7 Safety)
+- **User Stories**: 7 (P0: US1, US7 | P1: US2, US3, US4, US5, US6)
+- **Parallel Opportunities**: 12 tasks marked [P]
+
+---
+
+## Phase 1: Setup
+
+**Goal**: Project scaffolding — gitignore, env vars, shared types.
+
+- [X] T001 Add `.gmail-tokens.json` to root `.gitignore`
+- [X] T002 Add `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` entries to `backend/.env.example` (already present — verify; add Gmail-specific comments)
+- [X] T003 Create shared Gmail type interfaces (`GmailTokenStore`, `GmailTokenEntry`, `EmailSummary`, `AttachmentMeta`, `EmailDraft`, `ReplyDraft`, `DraftResult`, `EmailListResult`) in `backend/src/types/email.ts`
+
+---
+
+## Phase 2: Foundation (Blocking)
+
+**Goal**: Email service core — token management, Gmail API client, retry logic, logging. All user story phases depend on this.
+
+- [X] T004 Implement `EmailService` singleton class skeleton with constructor, logger child, and Google OAuth2 client factory in `backend/src/services/emailService.ts`
+- [X] T005 Implement token CRUD methods in `EmailService`: `getTokens(userId)`, `saveTokens(userId, tokens)`, `removeTokens(userId)`, `isConnected(userId)` — reads/writes `backend/.gmail-tokens.json` in `backend/src/services/emailService.ts`
+- [X] T006 Implement `getAuthClient(userId)` in `EmailService` that reads tokens, creates `google.auth.OAuth2` client, checks expiry, auto-refreshes if expired, and persists refreshed tokens in `backend/src/services/emailService.ts`
+- [X] T007 Implement exponential backoff retry wrapper (`withRetry`) for Gmail API 429 responses (delays 1s, 2s, 4s, max 3 retries) as private method in `backend/src/services/emailService.ts`
+- [X] T008 Add email PII redaction paths (`emailBody`, `emailSubject`, `emailContent`, `body`, `subject`) to pino redact config in `backend/src/config/logger.ts`
+- [X] T009 Implement private email parsing helpers in `EmailService`: `parseEmail(message)` extracts headers/metadata into `EmailSummary`, `extractBody(payload)` walks MIME parts for text/plain or text/html fallback, `truncateBody(text, maxBytes)` truncates at 50KB with `[truncated]` marker in `backend/src/services/emailService.ts`
+- [X] T010 Unit tests for EmailService core: token CRUD, getAuthClient with refresh, withRetry backoff, parseEmail/extractBody/truncateBody helpers — mock `googleapis` and filesystem in `backend/tests/services/emailService.test.ts`
+
+---
+
+## Phase 3: User Story 1 — Gmail OAuth2 Connection (P0)
+
+**Goal**: User can connect their Gmail account via browser-based OAuth2 flow. Tokens are stored, refreshed automatically, and errors are clear.
+
+**Independent Test**: Complete OAuth2 flow, store tokens, restart server, verify stored refresh token auto-obtains new access token.
+
+- [X] T011 [US1] Create `gmailAuthRoutes` Express router with `GET /auth/gmail` endpoint that redirects to Google consent URL with `gmail.readonly` + `gmail.compose` scopes, `access_type=offline`, `prompt=consent`, and `state={userId}` in `backend/src/routes/gmailAuthRoutes.ts`
+- [X] T012 [US1] Implement `GET /auth/gmail/callback` endpoint that exchanges authorization code for tokens, saves via `EmailService.saveTokens()`, returns HTML confirmation page, and handles denied/missing code errors in `backend/src/routes/gmailAuthRoutes.ts`
+- [X] T013 [US1] Implement `GET /auth/gmail/status` endpoint that returns `{connected, email, scopes}` or `{connected: false, authorizeUrl}` in `backend/src/routes/gmailAuthRoutes.ts`
+- [X] T014 [US1] Mount `gmailAuthRoutes` under `/api/v1` in `backend/src/server.ts` (the callback route needs to be accessible without auth middleware — mount before `authMiddleware` or handle within route)
+- [X] T015 [US1] Integration tests for OAuth routes via supertest: redirect URL construction, callback with valid code, callback with denied access, status endpoint (connected / not connected) in `backend/tests/routes/gmailAuth.test.ts`
+
+---
+
+## Phase 4: User Story 2 — Read Inbox (P1)
+
+**Goal**: User can ask "show me my unread emails" and receive a formatted list with metadata and snippets.
+
+**Independent Test**: Ask "show me my unread emails" — verify response lists emails with sender, subject, date, snippet. No full body unless explicitly requested.
+
+- [X] T016 [US2] Implement `listEmails(userId, filter, maxResults, dateRange?, includeBody?)` method in `EmailService` that calls `gmail.users.messages.list` with query filters, fetches each message with `gmail.users.messages.get`, parses via `parseEmail()`, returns `EmailListResult` in `backend/src/services/emailService.ts`
+- [X] T017 [US2] Implement `getEmail(userId, emailId, includeBody)` method in `EmailService` that fetches a single message and returns `EmailSummary` (with optional body) in `backend/src/services/emailService.ts`
+- [X] T018 [P] [US2] Create `read_emails` tool following `RunnableTool` interface with Zod schema (`filter`, `maxResults`, `dateRange`, `includeBody`), 15s timeout, delegates to `EmailService.listEmails()`, formats output as numbered list with sender/subject/date/snippet/attachments in `backend/src/tools/readEmails.ts`
+
+---
+
+## Phase 5: User Story 3 — Search Emails (P1)
+
+**Goal**: User can ask "find emails from Sarah about Q3 report" and receive matching results.
+
+**Independent Test**: Ask "find emails from john@example.com about project update" — verify correct Gmail query construction and relevant results.
+
+- [X] T019 [US3] Implement `searchEmails(userId, params)` method in `EmailService` that constructs Gmail query string from structured params (`from:`, `to:`, `subject:`, keywords, `after:`, `before:`, `has:attachment`), calls `gmail.users.messages.list`, fetches and parses results in `backend/src/services/emailService.ts`
+- [X] T020 [P] [US3] Create `search_emails` tool following `RunnableTool` interface with Zod schema (`from`, `to`, `subject`, `keywords`, `dateRange`, `hasAttachment`, `maxResults`, `includeBody`), 15s timeout, delegates to `EmailService.searchEmails()`, formats output same as read_emails in `backend/src/tools/searchEmails.ts`
+- [X] T021 Unit tests for read_emails and search_emails tools: Zod validation, email formatting, query construction, error handling — mock `EmailService` in `backend/tests/tools/readEmails.test.ts`
+
+---
+
+## Phase 6: User Stories 4, 5, 6 — Summarize, Draft, Reply (P1)
+
+**Goal**: User can summarize inbox, draft new emails, and reply to existing emails. All compose operations create Gmail drafts only — no sending.
+
+**Independent Test (US4)**: Ask "summarize my unread inbox" — verify grouped categories with counts.
+**Independent Test (US5)**: Ask to draft an email — verify it appears in Gmail Drafts with correct recipient/subject/body; no email sent.
+**Independent Test (US6)**: Ask to reply to a specific email — verify draft created in correct thread with proper `In-Reply-To`/`References` headers.
+
+### Summarize (US4)
+
+- [X] T022 [P] [US4] Create `summarize_emails` tool following `RunnableTool` interface with Zod schema (`filter`, `maxResults` up to 50), 30s timeout, delegates to `EmailService.listEmails()` with higher maxResults, formats raw email list for LLM categorization in `backend/src/tools/summarizeEmails.ts`
+
+### Draft (US5)
+
+- [X] T023 [US5] Implement `createDraft(userId, draft)` method in `EmailService` that builds RFC 2822 MIME message from `EmailDraft`, base64url-encodes it, calls `gmail.users.drafts.create`, returns `DraftResult` in `backend/src/services/emailService.ts`
+- [X] T024 [P] [US5] Create `draft_email` tool following `RunnableTool` interface with Zod schema (`to` with email validation, `subject`, `body`, `cc?`, `bcc?`), 10s timeout, delegates to `EmailService.createDraft()`, formats confirmation with recipient/subject/preview/draftId in `backend/src/tools/draftEmail.ts`
+
+### Reply (US6)
+
+- [X] T025 [US6] Implement `createReplyDraft(userId, emailId, body)` method in `EmailService` that fetches original email for thread context, extracts `Message-ID`/`References`/`threadId`, builds reply MIME with `In-Reply-To` and `References` headers, `Re:` subject prefix, creates draft in correct thread in `backend/src/services/emailService.ts`
+- [X] T026 [P] [US6] Create `reply_email` tool following `RunnableTool` interface with Zod schema (`emailId`, `body`), 10s timeout, delegates to `EmailService.createReplyDraft()`, formats confirmation with thread subject/recipient/preview/draftId in `backend/src/tools/replyEmail.ts`
+
+### Tests & Registration
+
+- [X] T027 Unit tests for summarize_emails, draft_email, and reply_email tools: Zod validation, draft creation, threading headers, error handling — mock `EmailService` in `backend/tests/tools/draftEmail.test.ts`
+- [X] T028 Register all 5 email tools (`readEmails`, `searchEmails`, `summarizeEmails`, `draftEmail`, `replyEmail`) in `backend/src/tools/index.ts`
+
+---
+
+## Phase 7: User Story 7 — Safety Guardrails & Polish (P0)
+
+**Goal**: Verify all safety constraints, edge cases, and cross-cutting concerns are met.
+
+**Independent Test**: Verify `read_emails` default output has no body content; confirm no tool can send email; check logs contain no PII.
+
+### Safety Verification
+
+- [X] T029 [US7] Verify OAuth2 scopes are exactly `gmail.readonly` + `gmail.compose` — no `gmail.send` scope requested anywhere in codebase
+- [X] T030 [US7] Verify no tool in the email system exposes send capability — only draft creation via `gmail.users.drafts.create` (audit all `EmailService` methods and tool files)
+- [X] T031 [US7] Verify default `read_emails` / `search_emails` tool output contains only metadata + snippet — no email body unless `includeBody: true`
+- [X] T032 [US7] Verify email body/subject PII redaction works in pino logs — log an email operation and confirm body/subject are `[REDACTED]`
+
+### Edge Cases
+
+- [X] T033 Validate edge case handling across all tools: HTML-only emails converted via `html-to-text`, 50KB truncation with `[truncated]` marker, attachment metadata included, UTF-8/international content preserved, empty inbox/search returns friendly message not error
+- [X] T034 Validate error handling across all tools: expired token triggers auto-refresh, revoked refresh token returns clear re-auth message, 429 rate limit triggers backoff then user-facing error, invalid email address in draft returns validation error, Gmail API network errors return actionable message
+
+### Cross-Cutting
+
+- [X] T035 Update Postman collection with Gmail OAuth endpoints (`GET /auth/gmail`, `GET /auth/gmail/callback`, `GET /auth/gmail/status`) in `docs/postman/chat-thread-api.postman_collection.json`
+- [X] T036 Run full test suite (`npm test` in backend), verify all tests pass and check coverage is reasonable for new code
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+  └──→ Phase 2 (Foundation + Tests)
+         ├──→ Phase 3 (US1: OAuth + Tests)
+         ├──→ Phase 4 (US2: Read)
+         │      └──→ Phase 5 (US3: Search + Tests for Read/Search)
+         │      └──→ Phase 6 (US4-6: Summarize/Draft/Reply + Tests)
+         └──→ Phase 7 (US7: Safety — runs last)
+```
+
+- **Phase 1 → Phase 2**: Types must exist before service implementation.
+- **Phase 2 → Phases 3-6**: `EmailService` core (tokens, auth client, parsing) blocks all tools.
+- **Phase 3 (OAuth)** can run in parallel with **Phases 4-6** after Phase 2 completes (OAuth routes and tools are independent).
+- **Phase 4 (Read)** should complete before Phase 5 (Search) since `searchEmails` reuses the same `listEmails`/parsing pattern.
+- **Phase 6** tasks are internally parallelizable: summarize, draft, and reply tools are independent.
+- **Phase 7** runs last — cross-cutting safety verification across all implemented code.
+
+## Parallel Execution Opportunities
+
+### After Phase 2 completes:
+- **Parallel group A**: T011-T015 (OAuth routes + tests) can run alongside T016-T018 (Read tool)
+- **Parallel group B**: T022 (Summarize tool), T024 (Draft tool), T026 (Reply tool) — all [P] marked, different files, no dependencies on each other
+
+### Within Phase 6:
+- T022 (summarize), T024 (draft), T026 (reply) are all independent tool files
+
+## Implementation Strategy
+
+1. **MVP (Phase 1-4)**: Setup + Foundation + OAuth + Read Inbox = minimal working feature. User can connect Gmail and read emails through chat.
+2. **Core (Phase 5-6)**: Add search, summarize, draft, and reply. Full tool suite available.
+3. **Hardening (Phase 7)**: Safety verification and edge case validation.
+
+**Suggested MVP scope**: Phases 1-4 (Tasks T001-T018). After MVP, a user can connect Gmail and ask "show me my unread emails" end-to-end through the chat UI.


### PR DESCRIPTION
Description:

  ## Summary

  - **Gmail OAuth2 flow** — connect/disconnect Gmail via browser-based
  consent, with automatic token refresh and secure file-based storage
  - **5 email tools** for the AI chat agent: `read_emails`, `search_emails`,
  `summarize_emails`, `draft_email`, `reply_email`
  - **Safety by design** — only `gmail.readonly` + `gmail.compose` scopes (no
  send), all compose operations create drafts only, email PII redacted from
  logs

  ## Details

  - `EmailService` singleton handles OAuth2 client management, token CRUD,
  Gmail API calls with exponential backoff retry, MIME parsing (text/plain +
  html-to-text fallback), and 50KB body truncation
  - OAuth routes: `GET /auth/gmail` (redirect to Google), `GET
  /auth/gmail/callback` (token exchange), `GET /auth/gmail/status` (connection
  check)
  - Tools registered in the tool registry and available to all AI models that
  support tool calling
  - Full test suite: unit tests for EmailService core, OAuth routes
  (supertest), and all 5 tools
  - Updated system prompt to guide models toward using email tools
  - Postman collection updated with OAuth endpoints

  ## Test plan

  - [ ] Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `.env`
  - [ ] Visit `http://localhost:5001/api/v1/auth/gmail` and complete OAuth
  flow
  - [ ] Verify `/auth/gmail/status` returns `connected: true`
  - [ ] Ask "show me my unread emails" in chat — verify `read_emails` tool is
  called
  - [ ] Ask "draft an email to test@example.com about hello" — verify draft
  appears in Gmail Drafts
  - [ ] Run `cd backend && npm test` — all tests pass